### PR TITLE
Change to replace Mongo with MongoClient

### DIFF
--- a/web/Xhgui/Db.php
+++ b/web/Xhgui/Db.php
@@ -12,7 +12,7 @@ class Xhgui_Db
         if (empty($host)) {
             $host = Xhgui_Config::read('db.host');
         }
-        $this->_mongo = new Mongo($host);
+        $this->_mongo = new MongoClient($host);
         $this->_db = $this->_mongo->xhprof;
         $this->_collection = $this->_db->{$collection};
         $this->_mapper = new Xhgui_Db_Mapper();


### PR DESCRIPTION
Mongo class has been Deprecated as of version 1.3.0 and replaced by
MongoClient

http://www.php.net/manual/en/class.mongo.php
