### PR TITLE
Fix unit on CPU time display (url.twig)

### DIFF
--- a/web/templates/runs/url.twig
+++ b/web/templates/runs/url.twig
@@ -27,7 +27,7 @@
             <td><a href="{{ url('/url.php', {'url': result.meta.url}) }}">{{ result.meta.url }}</a></td>
             <td><a href="{{ url('/run.php', {'id': result._id|trim }) }}">{{ result['meta']['SERVER']['REQUEST_TIME']|date(date_format) }}</a></td>
             <td class="right">{{ result.profile['main()']['wt'] |as_time }}</td>
-            <td class="right">{{ result.profile['main()']['cpu'] |as_bytes }}</td>
+            <td class="right">{{ result.profile['main()']['cpu'] |as_time }}</td>
             <td class="right">{{ result.profile['main()']['mu'] |as_bytes }}</td>
             <td class="right">{{ result.profile['main()']['pmu'] |as_bytes }}</td>
         </tr>


### PR DESCRIPTION
The unit on the CPU time was bytes instead of µs.
