### PR TITLE
Update README.md to mention about adding indexes to mongo db to improve the performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Installing the xhgui ui
 
 * If your mongodb setup requires a username + password, or isn't running on the default port + host.
   You'll need to update `web/config/config.php` so that it can connect to mongod.
+* After couple of runs, you may wish to add indexes (recommended) to improve the performance
+  You'll need to do this by using mongo console
+  On your command prompt (irrespective of Windows or *nix), start mogo using command 'mongo' and follow below commands to add the index
+
+  > use xhprof
+  > db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
+  > db.results.ensureIndex( { 'profile.main().wt' : -1 } )
+  > db.results.ensureIndex( { 'profile.main().mu' : -1 } )
+  > db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
+  > db.results.ensureIndex( { 'meta.url' : 1 } )
+  
+  Thats it you added the indexes
 
 Profiling an application / site
 -------------------------------


### PR DESCRIPTION
Without indexes, if you try to browse to 3rd, 4th page onward, Mongo Cursor throws a exception and asks us to add indexes so that performance is good

Adding these indexes solved the case

> db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
> db.results.ensureIndex( { 'profile.main().wt' : -1 } )
> db.results.ensureIndex( { 'profile.main().mu' : -1 } )
> db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
> db.results.ensureIndex( { 'meta.url' : 1 } )

Actually index "meta.SERVER.REQUEST_TIME" is enough, however as a best practice lets add all the keys we are using in our queries 
