### PR TITLE
Changes to Readme | Adding indexes for improving performance to avoid MongoCursor exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Installing the xhgui ui
   
   On your command prompt (irrespective of Windows or *nix), open mongo shell using command 'mongo' and follow below commands to add the index
 
-		  $ use xhprof
+		  $ mongo
+		  > use xhprof
 		  > db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
 		  > db.results.ensureIndex( { 'profile.main().wt' : -1 } )
 		  > db.results.ensureIndex( { 'profile.main().mu' : -1 } )


### PR DESCRIPTION
Without indexes, if you try to browse to 3rd, 4th page onward, Mongo Cursor throws a exception and asks us to add indexes so that performance is good

Adding these indexes solved the case

db.results.ensureIndex( { 'meta.SERVER.REQUEST_TIME' : -1 } )
db.results.ensureIndex( { 'profile.main().wt' : -1 } )
db.results.ensureIndex( { 'profile.main().mu' : -1 } )
db.results.ensureIndex( { 'profile.main().cpu' : -1 } )
db.results.ensureIndex( { 'meta.url' : 1 } )

Actually index "meta.SERVER.REQUEST_TIME" is enough, however as a best practice lets add all the keys we are using in our queries

Have formatted properly now
