### PR TITLE
 - First attempt at displaying the exclusive wall time data as a rose ch...

### DIFF
--- a/web/templates/runs/url.twig
+++ b/web/templates/runs/url.twig
@@ -42,7 +42,7 @@
 <script>
 $(document).ready(function () {
     var graphData = {{ chart_data|json_encode|raw }};
-    Xhgui.linegraph('#time-line-graph', graphData, {
+    Xhgui.rosechart('#time-line-graph', graphData, {
         series: ['avg_wt', 'avg_cpu'],
         height: 300,
         xAxis: 'date',

--- a/web/templates/runs/view.twig
+++ b/web/templates/runs/view.twig
@@ -130,7 +130,12 @@
 <script>
 $(document).ready(function () {
     var wallTime = {{ wall_time|json_encode|raw }};
-    Xhgui.columnchart('#wall-time-chart', wallTime, {
+    var other = {{ result.get('main()', 'wt') }};
+    for (var i = 0; i < wallTime.length; i++) {
+        other -= wallTime[i].value;
+    }
+    wallTime.push({'name' : 'Other', 'value' : other});
+    Xhgui.rosechart('#wall-time-chart', wallTime, {
         width: 350,
         height: 300,
         postfix: ' \u00b5s'

--- a/web/webroot/js/xhgui-charts.js
+++ b/web/webroot/js/xhgui-charts.js
@@ -236,6 +236,81 @@ Xhgui.piechart = function (container, data, options) {
     });
 };
 
+
+/**
+ * Create a rose chart.
+ *
+ * @param selector container The container for the chart
+ * @param array data The data list with name, value keys.
+ * @param object options
+ */
+Xhgui.rosechart = function (container, data, options) {
+    options = options || {};
+    var maxValue = 0;
+    var height = options.height || 400,
+        width = options.width || 400,
+        radius = Math.min(width, height) / 2;
+
+    var arc = d3.svg.arc()
+        .outerRadius(function (d) {
+            var num = (d.value - 20) * 10000;
+            return 100 / maxValue * num / 100 * (radius - 10);
+        })
+        .innerRadius(0);
+
+    var pie = d3.layout.pie()
+        .sort(null)
+        .value(function (d) {
+            var v = 20 + (d.value / 10000);
+            if (d.value > maxValue)
+            {
+                maxValue = d.value;
+            }
+            return v;
+        });
+
+    var color = Xhgui.colors();
+
+    container = d3.select(container);
+
+    var svg = container.append('svg')
+        .attr('width', width)
+        .attr('height', height)
+            .append('g')
+            .attr('transform', "translate(" + width / 2 + "," + height / 2 + ")");
+
+    var g = svg.selectAll('.chart-arc')
+        .data(pie(data))
+            .enter().append('g')
+        .attr('class', 'chart-arc');
+
+    g.append('path')
+        .attr('d', arc)
+        .style('fill', function (d) {
+            return color(d.data.value);
+        });
+
+    Xhgui.tooltip(container, {
+        bindTo: g,
+        positioner: function (d, i) {
+            var position, sliceX, sliceY;
+
+            position = arc.centroid(d, i);
+
+            // Recalculate base on outer transform.
+            sliceX = position[0] + (height / 2);
+            sliceY = position[1] + (width / 2);
+            return {x: sliceX, y: sliceY};
+        },
+        formatter: function (d, i) {
+            var label = '<strong>' + d.data.name +
+                '</strong><br />' +
+                Xhgui.formatNumber(d.data.value, 0) + options.postfix;
+            return label;
+        }
+    });
+};
+
 /**
  * Create a column chart.
  *


### PR DESCRIPTION
...art rather than a pie chart

We talked before about how we're presenting the data for the Exclusive wall time. I feel the data is most useful as something sort of pie chart like. We're showing portions of a whole. So I've done two things:
- Added Other, which is main().wt - sum(ones were showing.wt)
- Added a new rose stye pie chart through a series of hacks and other chicanery.

Now, as to my understanding the degrees in the arc consuming each portion of the pie chart should be equal. They're not here. I couldn't figure out how to return a fixed number for the value, and still get access to that number when calculating the desired radius. So I'm doing some chicanery storing the number in the decimal. Which is uber lame.

I'm prepared to put work into cleaning this up, but I wanted to get your thoughts first. The tooltip will need some work. 

Should look like this: http://screencast.com/t/PAsM5q6GEi
