### PR TITLE
Fixed incorrect parsing of numbers with more than one comma.

### DIFF
--- a/webroot/js/xhgui.js
+++ b/webroot/js/xhgui.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
                 return node.innerText;
             }
             var text = node.innerText || node.textContent;
-            return '' + parseInt(text.replace(',', ''), 10);
+            return '' + parseInt(text.replace(/,/g, ''), 10);
         }
     });
 


### PR DESCRIPTION
Not sure if I should submit this against master or the waterfall branch, but there is a bug where only the first comma is being trimmed when sorting cells. As a result, any times larger than 999,999 microseconds are mixed in with other results when you sort, rather than being at the top of the list.

So:

"200,000,000" would go through `.replace(',','')` resulting in "200000,000", which parseInt interprets as 200000.

I'm using a regex to replace all commas, instead.
