### PR TITLE
[bug fix] fix pagination in url.twig

### DIFF
--- a/src/templates/runs/url.twig
+++ b/src/templates/runs/url.twig
@@ -36,7 +36,7 @@
 
 {% include 'runs/paginated-list.twig' %}
 
-{{ helpers.pagination('url.view', paging, {url: url}) }}
+{{ helpers.pagination('url.view', paging, search) }}
 
 {% endblock %}
 


### PR DESCRIPTION
There is something wrong with the pagination of route `url/view`. `date_start=xxxx-xx-xx` and `date_end=xxxx-xx-xx` miss.
