### PR TITLE
Fix issue with correct autoload file if XHGui is being used as a dependency of another Composer project

### DIFF
--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,9 +1,14 @@
 <?php
 /**
- * Boostrapping and common utility definition.
+ * Bootstrapping and common utility definition.
  */
 define('XHGUI_ROOT_DIR', dirname(__DIR__));
-require XHGUI_ROOT_DIR . '/vendor/autoload.php';
+
+if (file_exists(XHGUI_ROOT_DIR . '/../autoload.php')) {
+	require XHGUI_ROOT_DIR . '/../autoload.php';
+} else {
+	require XHGUI_ROOT_DIR . '/vendor/autoload.php';
+}
 
 Xhgui_Config::load(XHGUI_ROOT_DIR . '/config/config.default.php');
 Xhgui_Config::load(XHGUI_ROOT_DIR . '/config/config.php');


### PR DESCRIPTION
Currently XHProf expects to have an own vendor subfolder with the autoload.php in it. In our project we want to use our own Composer file for the dependency management and we don't want to execute the install.php which would install another Composer version. So XHProf is a subproject in our projects' "vendor" folder.

Since Composer has a default autoload.php always in the "vendor" folder, I suggest changing the behaviour of the XHProf bootstrap.php to search for the default autoload.php in the vendor folder and only if it doesn't exist, using the XHProf autoload.php from the XHProf/vendor folder.
