### PR TITLE
Adding findOne() query to ensure connection state

### DIFF
--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -71,6 +71,7 @@ class Xhgui_ServiceContainer extends Pimple
                 $config['db.options'] = array();
             }
             $mongo = new MongoClient($config['db.host'], $config['db.options']);
+            $mongo->$config['db.db']->results->findOne();
 
             return $mongo->{$config['db.db']};
         });


### PR DESCRIPTION
- Without this in situations where MongoDB requires authentication
  the connection will be created, but the query attempt will fail in the
  Run controller, which throws an uncaught exception. Which is ugly, and
  sad.
