### PR TITLE
Rename exclusive to self

### DIFF
--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -66,9 +66,9 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $detailCount = $this->_app->config('detail.count');
         $result = $this->_profiles->get($request->get('id'));
 
-        $result->calculateExclusive();
+        $result->calculateSelf();
 
-        // Exclusive wall time graph
+        // Self wall time graph
         $timeChart = $result->extractDimension('ewt', $detailCount);
 
         // Memory Block
@@ -210,7 +210,7 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $symbol = $request->get('symbol');
 
         $profile = $this->_profiles->get($id);
-        $profile->calculateExclusive();
+        $profile->calculateSelf();
         list($parents, $current, $children) = $profile->getRelatives($symbol);
 
         $this->_template = 'runs/symbol-view.twig';

--- a/src/Xhgui/Profile.php
+++ b/src/Xhgui/Profile.php
@@ -79,10 +79,10 @@ class Xhgui_Profile
         return $a;
     }
 
-    protected function _diffKeys($a, $b, $includeExclusive = true)
+    protected function _diffKeys($a, $b, $includeSelf = true)
     {
         $keys = $this->_keys;
-        if ($includeExclusive) {
+        if ($includeSelf) {
             $keys = array_merge($keys, $this->_exclusiveKeys);
         }
         foreach ($keys as $key) {
@@ -91,11 +91,11 @@ class Xhgui_Profile
         return $a;
     }
 
-    protected function _diffPercentKeys($a, $b, $includeExclusive = true)
+    protected function _diffPercentKeys($a, $b, $includeSelf = true)
     {
         $out = array();
         $keys = $this->_keys;
-        if ($includeExclusive) {
+        if ($includeSelf) {
             $keys = array_merge($keys, $this->_exclusiveKeys);
         }
         foreach ($keys as $key) {
@@ -312,7 +312,7 @@ class Xhgui_Profile
      *
      * @return Xhgui_Profile A new instance with exclusive data set.
      */
-    public function calculateExclusive()
+    public function calculateSelf()
     {
         // Init exclusive values
         foreach ($this->_collapsed as &$data) {
@@ -399,8 +399,8 @@ class Xhgui_Profile
      * @return array An array of comparison data.
      */
     public function compare(Xhgui_Profile $head) {
-        $this->calculateExclusive();
-        $head->calculateExclusive();
+        $this->calculateSelf();
+        $head->calculateSelf();
 
         $keys = array_merge($this->_keys, $this->_exclusiveKeys);
         $emptyData = array_fill_keys($keys, 0);
@@ -464,7 +464,7 @@ class Xhgui_Profile
         if (!in_array($metric, $valid)) {
             throw new Exception("Unknown metric '$metric'. Cannot generate callgraph.");
         }
-        $this->calculateExclusive();
+        $this->calculateSelf();
 
         // Non exclusive metrics are always main() because it is the root call scope.
         if (in_array($metric, $this->_exclusiveKeys)) {

--- a/src/templates/runs/callgraph.twig
+++ b/src/templates/runs/callgraph.twig
@@ -22,10 +22,10 @@
                         <option value="wt" selected="selected">Wall time</option>
                         <option value="cpu">CPU time</option>
                         <option value="mu">Memory use</option>
-                        <option value="ewt">Exclusive wall time</option>
-                        <option value="ecpu">Exclusive CPU</option>
-                        <option value="emu">Exclusive memory use</option>
-                        <option value="epmu">Exclusive peak memory use</option>
+                        <option value="ewt">Self wall time</option>
+                        <option value="ecpu">Self CPU</option>
+                        <option value="emu">Self memory use</option>
+                        <option value="epmu">Self peak memory use</option>
                     </select>
                 </div>
                 <div class="control-group">

--- a/src/templates/runs/compare-details.twig
+++ b/src/templates/runs/compare-details.twig
@@ -67,10 +67,10 @@
         <tr>
             <th>Function</th>
             <th>Call Count</th>
-            <th>Exclusive Wall Time</th>
-            <th>Exclusive CPU</th>
-            <th>Exclusive Memory Usage</th>
-            <th>Exclusive Peak Memory Usage</th>
+            <th>Self Wall Time</th>
+            <th>Self CPU</th>
+            <th>Self Memory Usage</th>
+            <th>Self Peak Memory Usage</th>
             <th>Inclusive Wall Time</th>
             <th>Inclusive CPU</th>
             <th>Inclusive Memory Usage</th>

--- a/src/templates/runs/symbol-view.twig
+++ b/src/templates/runs/symbol-view.twig
@@ -17,10 +17,10 @@
             <tr>
                 <th>Function</th>
                 <th>Call Count</th>
-                <th>Exclusive Wall Time</th>
-                <th>Exclusive CPU</th>
-                <th>Exclusive Memory Usage</th>
-                <th>Exclusive Peak Memory Usage</th>
+                <th>Self Wall Time</th>
+                <th>Self CPU</th>
+                <th>Self Memory Usage</th>
+                <th>Self Peak Memory Usage</th>
                 <th>Inclusive Wall Time</th>
                 <th>Inclusive CPU</th>
                 <th>Inclusive Memory Usage</th>
@@ -59,10 +59,10 @@
             <tr>
                 <th>Function</th>
                 <th>Call Count</th>
-                <th>Exclusive Wall Time</th>
-                <th>Exclusive CPU</th>
-                <th>Exclusive Memory Usage</th>
-                <th>Exclusive Peak Memory Usage</th>
+                <th>Self Wall Time</th>
+                <th>Self CPU</th>
+                <th>Self Memory Usage</th>
+                <th>Self Peak Memory Usage</th>
 
                 <th>Inclusive Wall Time</th>
                 <th>Inclusive CPU</th>

--- a/src/templates/runs/view.twig
+++ b/src/templates/runs/view.twig
@@ -52,9 +52,9 @@
             <tr>
                 <th>Function</th>
                 <th class="right">Call Count</th>
-                <th class="right"><span class="tip" title="Exclusive wall time">ewt</span></th>
-                <th class="right"><span class="tip" title="Exclusive memory use">emu</span></th>
-                <th class="right"><span class="tip" title="Exclusive peak memory use">epmu</span></th>
+                <th class="right"><span class="tip" title="Self wall time">ewt</span></th>
+                <th class="right"><span class="tip" title="Self memory use">emu</span></th>
+                <th class="right"><span class="tip" title="Self peak memory use">epmu</span></th>
             </tr>
         </thead>
         <tbody>
@@ -85,7 +85,7 @@
 
     <div class="row-fluid">
         <div class="span6">
-          <h2>Exclusive Wall Time</h2>
+          <h2>Self Wall Time</h2>
           <div id="wall-time-chart" class="chart-container"></div>
           <dl>
           {% for value in wall_time %}
@@ -120,10 +120,10 @@
         <tr>
             <th>Function</th>
             <th>Call Count</th>
-            <th>Exclusive Wall Time</th>
-            <th>Exclusive CPU</th>
-            <th>Exclusive Memory Usage</th>
-            <th>Exclusive Peak Memory Usage</th>
+            <th>Self Wall Time</th>
+            <th>Self CPU</th>
+            <th>Self Memory Usage</th>
+            <th>Self Peak Memory Usage</th>
             <th>Inclusive Wall Time</th>
             <th>Inclusive CPU</th>
             <th>Inclusive Memory Usage</th>

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -132,10 +132,10 @@ class ProfileTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $result[0]);
     }
 
-    public function testCalculateExclusive()
+    public function testCalculateSelf()
     {
         $profile = new Xhgui_Profile($this->_fixture[1]);
-        $result = $profile->calculateExclusive()->getProfile();
+        $result = $profile->calculateSelf()->getProfile();
 
         $main = $result['main()'];
         $this->assertEquals(800, $main['emu']);


### PR DESCRIPTION
I've always found 'Exclusive' to be a bit confusing. Other profiling tools (KCachegrind, Webgrind) use 'Self' instead.
