### PR TITLE
for PHP 5.5, don't try to profile the builtins

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -65,7 +65,11 @@ if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
 }
 
 
-xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY);
+if(PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 4) {
+    xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY | XHPROF_FLAGS_NO_BUILTINS);
+} else {
+    xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY);
+}
 
 register_shutdown_function(function() {
     // ignore_user_abort(true) allows your PHP script to continue executing, even if the user has terminated their request.


### PR DESCRIPTION
I don't know if this is the best way to fix this problem but XHGui does not work out of the box on PHP 5.5 and I am hearing "XHGui doesn't work on newer vesrsions of PHP".  Actually it's XHProf that's causing the problem, and I've just been using this workaround for my PHP 5.5 projects - maybe there's a reason this isn't added already but in case there isn't, here you go.
