### PR TITLE
Make XHGui work with Uprofiler #112

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ xhgui
 
 A graphical interface for XHProf data built on MongoDB.
 
-This tool requires that [XHProf](http://pecl.php.net/package/xhprof) is
-installed, which is a PHP Extension that records and provides profiling data.
+This tool requires that [XHProf](http://pecl.php.net/package/xhprof) or 
+its fork [Uprofiler](https://github.com/FriendsOfPHP/uprofiler) is installed, 
+which is a PHP Extension that records and provides profiling data.
 XHGui (this tool) takes that information, saves it in MongoDB, and provides
 a convienent GUI for working with it.
 
@@ -12,7 +13,8 @@ a convienent GUI for working with it.
 System Requirements
 ===================
 
- * [XHProf](http://pecl.php.net/package/xhprof) to actually profile the data
+ * [XHProf](http://pecl.php.net/package/xhprof) or 
+   [Uprofiler](https://github.com/FriendsOfPHP/uprofiler) to actually profile the data
  * [MongoDB PHP](http://pecl.php.net/package/mongo) MongoDB PHP extension
  * [MongoDB](http://www.mongodb.org/) MongoDB Itself
  * [mcrypt] (http://php.net/manual/en/book.mcrypt.php) PHP must be configured

--- a/external/header.php
+++ b/external/header.php
@@ -18,6 +18,7 @@
  * XHPROF_FLAGS_NO_BUILTINS
  *  Omit built in functions from return
  *  This can be useful to simplify the output, but there's some value in seeing that you've called strpos() 2000 times
+ *  (disabled on PHP 5.5+ as it causes a segfault)
  *
  * XHPROF_FLAGS_CPU
  *  Include CPU profiling information in output
@@ -28,6 +29,18 @@
  *
  * Use bitwise operators to combine, so XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY to profile CPU and Memory
  *
+ */
+
+/* uprofiler support
+ * The uprofiler extension is a fork of xhprof.  See: https://github.com/FriendsOfPHP/uprofiler
+ *
+ * The two extensions are very similar, and this script will use the uprofiler extension if it is loaded, 
+ * or the xhprof extension if not.  At least one of these extensions must be present.
+ *
+ * The UPROFILER_* constants mirror the XHPROF_* ones exactly, with one additional constant available:
+ *
+ * UPROFILER_FLAGS_FUNCTION_INFO (integer)
+ *  Adds more information about function calls (this information is not currently used by XHGui)
  */
 
 // this file should not - under no circumstances - interfere with any other application


### PR DESCRIPTION
As Mark suggested, the uprofiler extension is very much compatible with the original xprof extension.  This pull request aims to make XHGui work with either.  It works with PHP 5.5 and uprofiler, with or without xhprof also being present.
