### PR TITLE
Don't install development dependencies

### DIFF
--- a/install.php
+++ b/install.php
@@ -61,7 +61,7 @@ if (!file_exists(__DIR__ . '/composer.phar')) {
 }
 
 out("Installing dependencies.");
-$cmd = 'php ' . __DIR__ . '/composer.phar update --prefer-dist';
+$cmd = 'php ' . __DIR__ . '/composer.phar update --prefer-dist --no-dev';
 $output = runProcess($cmd);
 out($output);
 


### PR DESCRIPTION
When I install XHGui, I just want to use the tool; I don't need PHPUnit etc