### PR TITLE
Check isset fractional part in request time

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -116,6 +116,9 @@ register_shutdown_function(
             ? $_SERVER['REQUEST_TIME']
             : time();
         $requestTimeFloat = explode('.', $_SERVER['REQUEST_TIME_FLOAT']);
+        if (!isset($requestTimeFloat[1])) {
+            $requestTimeFloat[1] = 0;
+        }
 
         if (Xhgui_Config::read('save.handler') === 'file') {
             $requestTs = array('sec' => $time, 'usec' => 0);


### PR DESCRIPTION
If the request time has 0 microseconds $_SERVER['REQUEST_TIME_FLOAT'] will not have a fractional part and explode will return just one element array. This results with notice errors about undefined index.