### PR TITLE
Allow minor version upgrade of twig.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.3.0",
         "slim/slim": "2.3.1",
         "slim/views": "0.1.0",
-        "twig/twig": "1.13.1",
+        "twig/twig": "^1.13.1",
         "pimple/pimple": "1.0.2"
     },
     "require-dev": {


### PR DESCRIPTION
I would also be satisfied with ~1.13 instead of ^1.13.1, though the latter hews closer to the original.