### PR TITLE
Fix failing twig render when a _SERVER[] setting contains a json enco…

### DIFF
--- a/src/templates/macros/helpers.twig
+++ b/src/templates/macros/helpers.twig
@@ -3,7 +3,11 @@
 {% for k, v in data %}
     <dt>{{ k }}</dt>
     <dd class="text-wrap">
-        {{ v|join(' ') }}
+        {% if not v is iterable %}
+          {{ v|join(' ') }}
+        {% else %}
+          {{ v|json_encode() }}
+        {% endif %}
     </dd>
 {% else %}
     <dt>No {{ name }} data</dt>


### PR DESCRIPTION
Our deployment environment is storing json encoded data in some of the _SERVER[] variables.

What happens here is that the data reaching the Twig template is the decoded object, and twig is unable to render it, making the whole page fail.

This is the error you get::

```
Fatal error: Uncaught exception 'ErrorException' with message 'Array to string conversion' in D:\_Webs\php_upcplus\runtime\xhgui\vendor\twig\twig\lib\Twig\Extension\Core.php:800 Stack trace: #0 [internal function]: Slim\Slim::handleErrors(8, 'Array to string...', 'D:\\_Webs\\php_up...', 800, Array) #1 D:\_Webs\php_upcplus\runtime\xhgui\vendor\twig\twig\lib\Twig\Extension\Core.php(800): implode(' ', Array) #2 D:\_Webs\php_upcplus\runtime\xhgui\cache\08\08cce354957a292a871b4a2e097e7e4d1c7e3e132bc21c5e9008774ab823cf9f.php(63): twig_join_filter(Array, ' ') #3 D:\_Webs\php_upcplus\runtime\xhgui\cache\37\37867a85bebe48034c6582db6af1337038a6a4a3c081b8ead6e0219f0cc082e7.php(101): __TwigTemplate_2f1132402f61832fc83ebb2272bee2342a02c2774d4fb037bec5b844bbe196ca->getproperty_list('SERVER', Array) #4 D:\_Webs\php_upcplus\runtime\xhgui\vendor\twig\twig\lib\Twig\Template.php(167): __TwigTemplate_b36f9957db542a39c1bf92807eeae6ef7114e6e06165bfb23ba553778d7d9861->block_content(Array, Array) #5 D:\_Webs\php_upcplus\runtime\xhgui\cache\95\95 in D:\_Webs\php_upcplus\runtime\xhgui\vendor\twig\twig\lib\Twig\Template.php on line 182
```