### PR TITLE
Fix web.config for XHGUI to work when deployed as a nested application

### DIFF
--- a/webroot/web.config
+++ b/webroot/web.config
@@ -3,9 +3,10 @@
     <system.webServer>
         <rewrite>
             <rules>
+                <clear/>
                 <rule name="rule 1n" stopProcessing="true">
                     <match url="^" />
-                    <action type="Rewrite" url="/index.php" appendQueryString="true" />
+                    <action type="Rewrite" url="index.php" appendQueryString="true" />
                     <conditions>
                         <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
                     </conditions>


### PR DESCRIPTION
This change will allow XHGUI to be deployed as a nested application in IIS servers (www.mysite.com/whatever/xhgui).

It does not affect already deployed sites.