### PR TITLE
Fix profiling rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ return array(
         if (strpos($url, '/blog') === 0) {
             return false;
         }
-        return rand(0, 100) === 42;
+        return rand(1, 100) === 42;
     }
 );
 ```

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -30,7 +30,7 @@ return array(
     // Profile 1 in 100 requests.
     // You can return true to profile every request.
     'profiler.enable' => function() {
-        return rand(0, 100) === 42;
+        return rand(1, 100) === 42;
     },
 
     'profiler.simple_url' => function($url) {


### PR DESCRIPTION
The documentations claim that the default profiling rate is 1:100, but in fact
it is 1:101, because rand()'s $min / $max arguments are inclusive.