### PR TITLE
Add a Jump to functions shortcut

### DIFF
--- a/src/templates/runs/view.twig
+++ b/src/templates/runs/view.twig
@@ -44,6 +44,9 @@
         <a href="{{ url('run.callgraph', {id: result.id|trim }) }}" class="btn back-link">
             View Callgraph
         </a>
+        <a href="#functions" class="btn back-link">
+            Jump to functions
+        </a>
 
         <h2>Watch Functions</h2>
 
@@ -116,6 +119,7 @@
 </div>
 
 <div class="row-fluid">
+  <a name="functions"></a>
   <table class="table table-hover table-sort" id="function-calls">
     <thead>
         <tr>


### PR DESCRIPTION
First of all, thank you for this tool :)

If the server sidebar is too long in the runs/view template, you will end scrolling on each run until you reach the functions table. I've added a shortcut next to the View Callgraph button and it's saving me tons of scrolling time.