### PR TITLE
Add hint to minimum version of MongoDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ XHGui has the following requirements:
    [Tideways](https://github.com/tideways/php-profiler-extension) to actually profile the data.
  * [MongoDB PHP](http://pecl.php.net/package/mongo) MongoDB PHP driver.
    XHGui requires verison 1.3.0 or later.
- * [MongoDB](http://www.mongodb.org/) MongoDB Itself.
+ * [MongoDB](http://www.mongodb.org/) MongoDB Itself. XHGui requires version 2.2.0 or later.
  * [mcrypt](http://php.net/manual/en/book.mcrypt.php) PHP must be configured
    with mcrypt (which is a dependency of Slim).
  * [dom](http://php.net/manual/en/book.dom.php) If you are running the tests


### PR DESCRIPTION
Running XHGui with MongoDB < 2.2 will lead to exceptions, like in #134. The minimum version should be indicated in the README. 