### PR TITLE
staticUrl (mapped to static in Twig templates) #157

### DIFF
--- a/src/Xhgui/Twig/Extension.php
+++ b/src/Xhgui/Twig/Extension.php
@@ -70,9 +70,23 @@ class Xhgui_Twig_Extension extends Twig_Extension
         return $this->_app->urlFor($name)  . $query;
     }
 
+	/**
+	 * Get the URL for static content relative to webroot
+	 *
+	 * @param string $path The file/path you want a link to
+	 * @return string url.
+	 */
     public function staticUrl($url)
     {
-        return $this->_app->request()->getRootUri() . '/' . $url;
+		$rootUri = $this->_app->request()->getRootUri();
+
+		// get URL part prepending index.php
+		$indexPos = strpos($rootUri, 'index.php');
+		if ( $indexPos > 0 ) {
+			return substr($rootUri,0,$indexPos) . $url;
+		} else {
+			return $rootUri . '/' . $url;
+		}
     }
 
     public function formatBytes($value)


### PR DESCRIPTION
 now returns path prepending index.php - should fix #157