### PR TITLE
Set exact flamegraph height and display output even if some fields are missing

### DIFF
--- a/src/Xhgui/Profile.php
+++ b/src/Xhgui/Profile.php
@@ -74,7 +74,15 @@ class Xhgui_Profile
     protected function _sumKeys($a, $b)
     {
         foreach ($this->_keys as $key) {
-            $a[$key] += $b[$key];
+            if (!isset($a[$key])) {
+                $a[$key] = 0;
+            }
+
+            if (isset($b[$key])) {
+                $a[$key] += $b[$key];
+    		} else {
+                $a[$key] += 0;
+            }
         }
         return $a;
     }

--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -186,7 +186,7 @@ class Xhgui_Profiles
             $index = max(round($result['raw_index']) - 1, 0);
             foreach ($keys as $key => $out) {
                 sort($result[$key]);
-                $result[$out] = $result[$key][$index];
+                $result[$out] = isset($result[$key][$index]) ? $result[$key][$index] : null;
                 unset($result[$key]);
             }
         }

--- a/src/templates/runs/flamegraph.twig
+++ b/src/templates/runs/flamegraph.twig
@@ -44,12 +44,14 @@
 <script src="{{ static('js/d3-tip-index.js') }}"></script>
 <script src="{{ static('js/d3.flameGraph.js') }}"></script>
 <script type="text/javascript">
+
 var width = parseInt($('#chart').css('width'), 10);
+var cellHeight = 18;
 
 var flameGraph = d3.flameGraph()
     .height(540)
     .width(width)
-    .cellHeight(18)
+    .cellHeight(cellHeight)
     .transitionDuration(750)
     .transitionEase('cubic-in-out')
     .sort(true);
@@ -69,6 +71,9 @@ d3.json("{{ url('run.flamegraph.data', {id: profile.id|trim }) }}", function(err
     if (error) {
         return console.warn(error);
     }
+
+    flameGraph.height(getDepth(data) * cellHeight);
+
     d3.select("#chart")
         .datum(data)
         .call(flameGraph);
@@ -93,5 +98,19 @@ $('#flamegraph-clear').on('click', function() {
 $('#flamegraph-reset').on('click', function () {
     flameGraph.resetZoom();
 });
+
+function getDepth (obj) {
+    var depth = 0;
+    if (obj.children) {
+        obj.children.forEach(function (d) {
+            var tmpDepth = getDepth(d)
+            if (tmpDepth > depth) {
+                depth = tmpDepth
+            }
+        })
+    }
+    return 1 + depth
+}
+
 </script>
 {% endblock %}


### PR DESCRIPTION
1. Don't error out when of field (eg. cpu) is not in the profile. (I had this issue because the xhprof profiler that I used, which had PHP 7 compatibility didn't output the cpu field, so xhgui was displaying an error).

2. Flamegraphs are great bud didn't display the whole thing when the height is above 540 (fixed), so I got a function from SO to compute the depth of the data and use that as the height multiplied by the row height.