### PR TITLE
Sort flamegraph by call order instead of by name.

### DIFF
--- a/src/Xhgui/Profile.php
+++ b/src/Xhgui/Profile.php
@@ -604,7 +604,7 @@ class Xhgui_Profile
 
         $this->_visited = $this->_nodes = $this->_links = array();
         $flamegraph = $this->_flamegraphData(self::NO_PARENT, $main, $metric, $threshold);
-        return array_shift($flamegraph);
+        return array('data' => array_shift($flamegraph), 'sort' => $this->_visited);
     }
 
     protected function _flamegraphData($parentName, $main, $metric, $threshold, $parentIndex = null)

--- a/src/templates/runs/flamegraph.twig
+++ b/src/templates/runs/flamegraph.twig
@@ -72,10 +72,14 @@ d3.json("{{ url('run.flamegraph.data', {id: profile.id|trim }) }}", function(err
         return console.warn(error);
     }
 
-    flameGraph.height(getDepth(data) * cellHeight);
+    flameGraph.height(getDepth(data.data) * cellHeight);
+
+    flameGraph.sort(function (a, b) {
+        return data.sort[a.name] - data.sort[b.name];
+    });
 
     d3.select("#chart")
-        .datum(data)
+        .datum(data.data)
         .call(flameGraph);
 });
 

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -482,13 +482,19 @@ class ProfileTest extends PHPUnit_Framework_TestCase
         $profile = new Xhgui_Profile($fixture);
         $result = $profile->getFlamegraph();
         $expected = array(
-            'name' => 'main()',
-            'value' => 50139,
-            'children' => array(
-                array(
-                    'name' => 'strpos()',
-                    'value' => 600
-                )
+            'data' => array(
+                'name' => 'main()',
+                'value' => 50139,
+                'children' => array(
+                    array(
+                        'name' => 'strpos()',
+                        'value' => 600
+                    )
+                ),
+            ),
+            'sort' => array(
+                'main()' => 0,
+                'strpos()' => 1
             )
         );
         $this->assertEquals($expected, $result);


### PR DESCRIPTION
I noticed the that flamegraph was not order by call from left to right, but instead sorted by name.  This pull request sorts the functions by call order from left to right using $this->_visited array passed through json.

There might be a quicker way to do this (without using $this->_visited) because I noticed the the returned json is already sorted, so maybe returning -1 in the sort function will sort it properly anyway).  But I went with the more correct way.