### PR TITLE
build: Update Slim to 2.6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ XHGui has the following requirements:
  * [MongoDB Extension](http://pecl.php.net/package/mongo) MongoDB PHP driver.
    XHGui requires verison 1.3.0 or later.
  * [MongoDB](http://www.mongodb.org/) MongoDB Itself. XHGui requires version 2.2.0 or later.
- * [mcrypt](http://php.net/manual/en/book.mcrypt.php) PHP must be configured
-   with mcrypt (which is a dependency of Slim).
  * [dom](http://php.net/manual/en/book.dom.php) If you are running the tests
    you'll need the DOM extension (which is a dependency of PHPUnit).
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "slim/slim": "2.3.1",
+        "slim/slim": "2.6.3",
         "slim/views": "0.1.0",
         "twig/twig": "~1.17",
         "pimple/pimple": "1.0.2"


### PR DESCRIPTION
Release notes:
- https://github.com/slimphp/Slim/releases/tag/2.4.0
- https://github.com/slimphp/Slim/releases/tag/2.5.0
- https://github.com/slimphp/Slim/releases/tag/2.6.0

Also remove mention of mcrypt dependency from the readme, which
was removed from Slim in 2.4.0.

Fixes #192.