### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "perftools/xhgui",
     "description": "A web based interface for viewing profile data collected by XHProf.",
-    "version": "0.1",
     "license": "MIT",
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
remove `version` from `composer.json`. perhaps it's the reason packagist.org does not have versions for this project?

https://packagist.org/packages/perftools/xhgui

 - dev-master
 - dev-config_profile
 - dev-authenticate