### PR TITLE
fix delimiter for specific cases

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -130,7 +130,9 @@ register_shutdown_function(
         $time = array_key_exists('REQUEST_TIME', $_SERVER)
             ? $_SERVER['REQUEST_TIME']
             : time();
-        $requestTimeFloat = explode('.', $_SERVER['REQUEST_TIME_FLOAT']);
+        // In some cases there is comma instead of dot
+        $delimiter = (strpos($_SERVER['REQUEST_TIME_FLOAT'], ',') !== false) ? ',' : '.';
+        $requestTimeFloat = explode($delimiter, $_SERVER['REQUEST_TIME_FLOAT']);
         if (!isset($requestTimeFloat[1])) {
             $requestTimeFloat[1] = 0;
         }


### PR DESCRIPTION
In one of my projects (written using laravel 5.4) i have comma instead of dot as a result MongoDate throw exception