### PR TITLE
Ability to specify profiler options

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -35,6 +35,8 @@ return array(
 
     'profiler.simple_url' => function($url) {
         return preg_replace('/\=\d+/', '', $url);
-    }
+    },
+
+    'profiler.options' => array(),
 
 );

--- a/external/header.php
+++ b/external/header.php
@@ -86,15 +86,16 @@ if (!isset($_SERVER['REQUEST_TIME_FLOAT'])) {
     $_SERVER['REQUEST_TIME_FLOAT'] = microtime(true);
 }
 
+$options = Xhgui_Config::read('profiler.options');
 if (extension_loaded('uprofiler')) {
-    uprofiler_enable(UPROFILER_FLAGS_CPU | UPROFILER_FLAGS_MEMORY);
+    uprofiler_enable(UPROFILER_FLAGS_CPU | UPROFILER_FLAGS_MEMORY, $options);
 } else if (extension_loaded('tideways')) {
-    tideways_enable(TIDEWAYS_FLAGS_CPU | TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_NO_SPANS);
+    tideways_enable(TIDEWAYS_FLAGS_CPU | TIDEWAYS_FLAGS_MEMORY | TIDEWAYS_FLAGS_NO_SPANS, $options);
 } else {
     if (PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION > 4) {
-        xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY | XHPROF_FLAGS_NO_BUILTINS);
+        xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY | XHPROF_FLAGS_NO_BUILTINS, $options);
     } else {
-        xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY);
+        xhprof_enable(XHPROF_FLAGS_CPU | XHPROF_FLAGS_MEMORY, $options);
     }
 }
 


### PR DESCRIPTION
Closes #213
Introducting new config option `profiler.options`.
For example you can set following:
```php
return array(
    'profiler.options' => array(
        'ignored_functions' => ('call_user_func', 'call_user_func_array'),
    ),
);
```