### PR TITLE
Use non-aggregated data when generating the flamegraph.

### DIFF
--- a/src/Xhgui/Profile.php
+++ b/src/Xhgui/Profile.php
@@ -577,9 +577,11 @@ class Xhgui_Profile
     /**
      * Return a structured array suitable for generating flamegraph visualizations.
      *
-     * Functions whose inclusive time is less than 1% of the total time will
+     * Functions whose inclusive time is less than $threshold of the total time will
      * be excluded from the callgraph data.
      *
+     * @param string $metric The metric name to aggregate on.
+     * @param float $threshold The total % below which data should be elided.
      * @return array
      */
     public function getFlamegraph($metric = 'wt', $threshold = 0.01)
@@ -612,7 +614,6 @@ class Xhgui_Profile
 
         $children = $this->_indexed[$parentName];
         foreach ($children as $childName => $metrics) {
-            $metrics = $this->_collapsed[$childName];
             if ($metrics[$metric] / $main <= $threshold) {
                 continue;
             }

--- a/src/templates/runs/flamegraph.twig
+++ b/src/templates/runs/flamegraph.twig
@@ -85,7 +85,7 @@ d3.json("{{ url('run.flamegraph.data', {id: profile.id|trim }) }}", function(err
 $(document).ready(function(){
     $("form").submit(function(event){
         event.preventDefault();
-        search();
+        flameGraph.search($('#term').val());
     });
 });
 

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -566,7 +566,7 @@ class ProfileTest extends PHPUnit_Framework_TestCase
                         'children' => array(
                             array(
                                 'name' => 'util()',
-                                'value' => 5000,
+                                'value' => 1500,
                                 'children' => array(
                                     array(
                                         'name' => 'util_helper()',
@@ -582,7 +582,7 @@ class ProfileTest extends PHPUnit_Framework_TestCase
                         'children' => array(
                             array(
                                 'name' => 'util()',
-                                'value' => 5000
+                                'value' => 3500
                             ),
                         ),
                     ),


### PR DESCRIPTION
This will help reduce the number of flame towers with wide blocks on top of narrow ones, allowing us to upgrade d3.flamegraph more easily.

We can't entirely remove the wide blocks on top of narrow ones, as xhprof does not expose enough data for deeply nested call stacks. We could apply heuristics to ensure that a child is always lesser than its parent, but we will report data inaccurately with that approach.

Refs #216 