### PR TITLE
add autoload file

### DIFF
--- a/external/header.php
+++ b/external/header.php
@@ -2,5 +2,8 @@
 // Use the config directory defined in the xhgui application.
 define('XHGUI_CONFIG_DIR', dirname(__DIR__) . '/config/');
 
+//Include autoload
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
 // Include collector script.
 require_once dirname(__DIR__) . '/vendor/perftools/xhgui-collector/external/header.php';


### PR DESCRIPTION
while i used without ext-mongo(php5.6 & php7.2), show me some error:

```
PHP Fatal error:  Interface 'Alcaeus\MongoDbAdapter\TypeInterface' not found in /mnt/hgfs/projects/xhprof/xhgui/vendor/alcaeus/mongo-php-adapter/lib/Mongo/MongoDate.php on line 24

Fatal error: Interface 'Alcaeus\MongoDbAdapter\TypeInterface' not found in /mnt/hgfs/projects/xhprof/xhgui/vendor/alcaeus/mongo-php-adapter/lib/Mongo/MongoDate.php on line 24
```

because of in my project,just include header.php
`require '/data/projects/xhprof/xhgui/external/header.php';`

when i review code,find has not include autoload file.

