### PR TITLE
Workdir-independent tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/composer.lock
 /composer.phar
 /tags
 /vendor

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -138,7 +138,7 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
 
     public function testCallgraph()
     {
-        loadFixture($this->profiles, 'tests/fixtures/results.json');
+        loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
         Environment::mock(array(
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
@@ -154,7 +154,7 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
 
     public function testCallgraphData()
     {
-        loadFixture($this->profiles, 'tests/fixtures/results.json');
+        loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
         Environment::mock(array(
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -5,7 +5,7 @@ class ProfileTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         parent::setUp();
-        $contents = file_get_contents('tests/fixtures/results.json');
+        $contents = file_get_contents(XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
         $this->_fixture = json_decode($contents, true);
     }
 

--- a/tests/ProfilesTest.php
+++ b/tests/ProfilesTest.php
@@ -5,7 +5,7 @@ class ProfilesTest extends PHPUnit_Framework_TestCase
     {
         $di = Xhgui_ServiceContainer::instance();
         $this->profiles = $di['profiles'];
-        loadFixture($this->profiles, 'tests/fixtures/results.json');
+        loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
     }
 
     public function testPagination()

--- a/tests/Saver/FileTest.php
+++ b/tests/Saver/FileTest.php
@@ -4,13 +4,13 @@ class Saver_FileTest extends PHPUnit_Framework_TestCase
 {
     public function testSave()
     {
-        $data = file_get_contents('tests/fixtures/results.json');
-        
+        $data = file_get_contents(XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
+
         $file = tempnam(sys_get_temp_dir(), "xhgui");
-        
+
         $saver = new Xhgui_Saver_File($file);
         $saver->save($data);
-        
+
         $this->assertEquals(json_encode($data).PHP_EOL, file_get_contents($file));
     }
 

--- a/tests/Saver/MongoTest.php
+++ b/tests/Saver/MongoTest.php
@@ -4,7 +4,7 @@ class Saver_MongoTest extends PHPunit_Framework_TestCase
 {
     public function testSave()
     {
-        $data = file_get_contents('tests/fixtures/results.json');
+        $data = file_get_contents(XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
 
         $profiles = $this->getMockBuilder('Xhgui_Profiles')
             ->disableOriginalConstructor()


### PR DESCRIPTION
Currently the unit tests need to be run from the project root directory, otherwise PHP cannot find the `tests/fixtures/results.json` file. I simply leveraged an existing constant to convert these paths to their absolute form. With this change the test suite can now be run directly from PHPStorm, and possibly other IDEs.

Also composer.lock has been ignored to avoid accidentally committing it.