### PR TITLE
add link to delete run from the main paginated list page

### DIFF
--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -108,6 +108,19 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         ));
     }
 
+    public function delete()
+    {
+        $request = $this->app->request();
+        $id = $request->get('id');
+
+        $delete = $this->profiles->delete($id);
+
+        $this->_template = 'runs/delete.twig';
+        $this->set(array(
+          'id' => $id,
+        ));
+    }
+
     public function url()
     {
         $request = $this->app->request();

--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -267,6 +267,17 @@ class Xhgui_Profiles
     }
 
     /**
+     * Delete a profile run.
+     *
+     * @param $id The profile id to delete.
+     * @return array|bool
+     */
+    public function delete($id)
+    {
+        return $this->_collection->remove(array('_id' => new MongoId($id)), array());
+    }
+
+    /**
      * Used to truncate a collection.
      *
      * Primarly used in test cases to reset the test db.

--- a/src/routes.php
+++ b/src/routes.php
@@ -30,6 +30,11 @@ $app->get('/run/view', function () use ($di, $app) {
     $app->controller->view();
 })->name('run.view');
 
+$app->get('/run/delete', function () use ($di, $app) {
+    $app->controller = $di['runController'];
+    $app->controller->delete();
+})->name('run.delete');
+
 $app->get('/url/view', function () use ($di, $app) {
     $app->controller = $di['runController'];
     $app->controller->url();

--- a/src/templates/runs/delete.twig
+++ b/src/templates/runs/delete.twig
@@ -1,0 +1,9 @@
+{% extends 'layout/base.twig' %}
+
+{% block title %}
+    - Profile - {{ id }}
+{% endblock %}
+
+{% block content %}
+Deleted profile {{ id }}
+{% endblock %}

--- a/src/templates/runs/paginated-list.twig
+++ b/src/templates/runs/paginated-list.twig
@@ -34,6 +34,9 @@
                         {{ helpers.sort_link('pmu', base_url, 'pmu', paging, search) }}
                     </span>
                 </th>
+                <th>
+                    Ops
+                </th>
             </tr>
         </thead>
         <tbody>
@@ -69,6 +72,11 @@
             <td class="right">{{ result.get('main()', 'cpu') |as_time }}</td>
             <td class="right">{{ result.get('main()', 'mu') |as_bytes }}</td>
             <td class="right">{{ result.get('main()', 'pmu') |as_bytes }}</td>
+            <td>
+                <a href="{{ url('run.delete', {'id': result.id|trim }) }}">
+                    <i class="icon-trash"></i>
+                </a>
+            </td>
         </tr>
         {% else %}
         <tr>


### PR DESCRIPTION
I needed a way to delete profile runs and after seeing there was no progress on issue #136 I decided to quickly put something together.

It's just a simple delete button on the paginated list template which takes you to a new delete route and deletes the run.

It would be nice to have it as an ajax request maybe so you stay on the page you are on but I didn't have time for that, and this is still better than nothing.

Let me know if there are any issues and I can fix and recommit.