### PR TITLE
Add link to delete all  run from the main paginated list page

### DIFF
--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -124,19 +124,19 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $this->app->redirect($redirect);
     }
 
-    public function delete_all()
+    public function deleteAll()
     {
-      $request = $this->app->request();
+        $request = $this->app->request();
 
-      // Delete all profile runs.
-      $delete = $this->profiles->truncate();
+        // Delete all profile runs.
+        $delete = $this->profiles->truncate();
 
-      $this->app->flash('success', 'Deleted all profiles');
+        $this->app->flash('success', 'Deleted all profiles');
 
-      $referrer = $request->getReferrer();
-      // In case route is accessed directly the referrer is not set.
-      $redirect = isset($referrer) ? $referrer : $this->app->urlFor('home');
-      $this->app->redirect($redirect);
+        $referrer = $request->getReferrer();
+        // In case route is accessed directly the referrer is not set.
+        $redirect = isset($referrer) ? $referrer : $this->app->urlFor('home');
+        $this->app->redirect($redirect);
     }
 
     public function url()

--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -124,6 +124,20 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $this->app->redirect($redirect);
     }
 
+    public function delete_all() {
+      $request = $this->app->request();
+
+      // Delete all profile runs.
+      $delete = $this->profiles->truncate();
+
+      $this->app->flash('success', 'Deleted all profiles');
+
+      $referrer = $request->getReferrer();
+      // In case route is accessed directly the referrer is not set.
+      $redirect = isset($referrer) ? $referrer : $this->app->urlFor('home');
+      $this->app->redirect($redirect);
+    }
+
     public function url()
     {
         $request = $this->app->request();

--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -124,7 +124,8 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $this->app->redirect($redirect);
     }
 
-    public function delete_all() {
+    public function delete_all()
+    {
       $request = $this->app->request();
 
       // Delete all profile runs.

--- a/src/routes.php
+++ b/src/routes.php
@@ -34,6 +34,10 @@ $app->get('/run/delete', function () use ($di, $app) {
     $di['runController']->delete();
 })->name('run.delete');
 
+$app->get('/run/delete_all', function () use ($di, $app) {
+  $di['runController']->delete_all();
+})->name('run.delete_all');
+
 $app->get('/url/view', function () use ($di, $app) {
     $app->controller = $di['runController'];
     $app->controller->url();

--- a/src/routes.php
+++ b/src/routes.php
@@ -35,7 +35,7 @@ $app->get('/run/delete', function () use ($di, $app) {
 })->name('run.delete');
 
 $app->get('/run/delete_all', function () use ($di, $app) {
-  $di['runController']->delete_all();
+    $di['runController']->delete_all();
 })->name('run.deleteAll');
 
 $app->get('/url/view', function () use ($di, $app) {

--- a/src/routes.php
+++ b/src/routes.php
@@ -36,7 +36,7 @@ $app->get('/run/delete', function () use ($di, $app) {
 
 $app->get('/run/delete_all', function () use ($di, $app) {
   $di['runController']->delete_all();
-})->name('run.delete_all');
+})->name('run.deleteAll');
 
 $app->get('/url/view', function () use ($di, $app) {
     $app->controller = $di['runController'];

--- a/src/routes.php
+++ b/src/routes.php
@@ -35,7 +35,7 @@ $app->get('/run/delete', function () use ($di, $app) {
 })->name('run.delete');
 
 $app->get('/run/delete_all', function () use ($di, $app) {
-    $di['runController']->delete_all();
+    $di['runController']->deleteAll();
 })->name('run.deleteAll');
 
 $app->get('/url/view', function () use ($di, $app) {

--- a/src/templates/runs/list.twig
+++ b/src/templates/runs/list.twig
@@ -10,7 +10,7 @@
 
 {% if runs|length or has_search %}
 <div class="searchbar clearfix">
-    <a href="{{ url('run.delete_all') }}" class="pull-right btn btn-small delete-all" title="Delete all">
+    <a href="{{ url('run.deleteAll') }}" class="pull-right btn btn-small delete-all" title="Delete all">
         <i class="icon-trash"></i> Delete all
     </a>
 

--- a/src/templates/runs/list.twig
+++ b/src/templates/runs/list.twig
@@ -10,6 +10,10 @@
 
 {% if runs|length or has_search %}
 <div class="searchbar clearfix">
+    <a href="{{ url('run.delete_all') }}" class="pull-right btn btn-small delete-all" title="Delete all">
+        <i class="icon-trash"></i> Delete all
+    </a>
+
     <a href="#" class="pull-right btn btn-small search-expand" title="Show search form">
         <i class="icon-search"></i> Search
     </a>

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -212,7 +212,7 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
         $result = $this->profiles->getAll();
         $this->assertCount(5, $result['results']);
 
-        $this->runs->delete_all();
+        $this->runs->deleteAll();
 
         $result = $this->profiles->getAll();
         $this->assertCount(0, $result['results']);

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -192,4 +192,29 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
         $result = $this->profiles->getAll();
         $this->assertCount(4, $result['results']);
     }
+
+    public function testDeleteAll()
+    {
+      loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
+
+      Environment::mock(array(
+        'SCRIPT_NAME' => 'index.php',
+        'PATH_INFO' => '/run/delete_all',
+      ));
+
+      $this->app->expects($this->once())
+        ->method('urlFor')
+        ->with('home');
+
+      $this->app->expects($this->once())
+        ->method('redirect');
+
+      $result = $this->profiles->getAll();
+      $this->assertCount(5, $result['results']);
+
+      $this->runs->delete_all();
+
+      $result = $this->profiles->getAll();
+      $this->assertCount(0, $result['results']);
+    }
 }

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -195,26 +195,26 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
 
     public function testDeleteAll()
     {
-      loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
+        loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
 
-      Environment::mock(array(
-        'SCRIPT_NAME' => 'index.php',
-        'PATH_INFO' => '/run/delete_all',
-      ));
+        Environment::mock(array(
+          'SCRIPT_NAME' => 'index.php',
+          'PATH_INFO' => '/run/delete_all',
+        ));
 
-      $this->app->expects($this->once())
-        ->method('urlFor')
-        ->with('home');
+        $this->app->expects($this->once())
+          ->method('urlFor')
+          ->with('home');
 
-      $this->app->expects($this->once())
-        ->method('redirect');
+        $this->app->expects($this->once())
+          ->method('redirect');
 
-      $result = $this->profiles->getAll();
-      $this->assertCount(5, $result['results']);
+        $result = $this->profiles->getAll();
+        $this->assertCount(5, $result['results']);
 
-      $this->runs->delete_all();
+        $this->runs->delete_all();
 
-      $result = $this->profiles->getAll();
-      $this->assertCount(0, $result['results']);
+        $result = $this->profiles->getAll();
+        $this->assertCount(0, $result['results']);
     }
 }


### PR DESCRIPTION
Added a link next to the 'search' button to delete all runs as the only other way to truncate the whole profiles database was to go into mongo and drop the database. 

Works pretty much like the individual run deletion functionality but it uses the `truncate` function to drop everything.