### PR TITLE
added mandatory 'cursor' parameter to mongo aggregate method call

### DIFF
--- a/src/Xhgui/Profiles.php
+++ b/src/Xhgui/Profiles.php
@@ -232,7 +232,9 @@ class Xhgui_Profiles
                 )
             ),
             array('$sort' => array('_id' => 1))
-        ));
+        ),
+            array('cursor' => array('batchSize' => 0))
+        );
         if (empty($results['result'])) {
             return array();
         }


### PR DESCRIPTION
This PR fixes issue #241 

On MongoDB 3.5 and up the `cursor` parameter is mandatory when calling `aggregate()`. #221 indeed fixed the same issue in another call of the same method.