### PR TITLE
Restore Twig template path

### DIFF
--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -32,6 +32,7 @@ class Xhgui_ServiceContainer extends Pimple
             // Configure Twig view for slim
             $view = new Twig();
 
+            $view->twigTemplateDirs = array(dirname(__DIR__) . '/templates');
             $view->parserOptions = array(
                 'charset' => 'utf-8',
                 'cache' => $cacheDir,


### PR DESCRIPTION
I'm not sure how 'templates.path' made its way to Slim\Views\Twigs, but it does.


This follows #249, which broke the twig template rendering for me locally (I guess for others as well). Oops!