### PR TITLE
Use POST for /runs/delete_all and add a confirmation form

### DIFF
--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -124,7 +124,12 @@ class Xhgui_Controller_Run extends Xhgui_Controller
         $this->app->redirect($redirect);
     }
 
-    public function deleteAll()
+    public function deleteAllForm()
+    {
+        $this->_template = 'runs/delete-all-form.twig';
+    }
+
+    public function deleteAllSubmit()
     {
         $request = $this->app->request();
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -35,8 +35,13 @@ $app->get('/run/delete', function () use ($di, $app) {
 })->name('run.delete');
 
 $app->get('/run/delete_all', function () use ($di, $app) {
-    $di['runController']->deleteAll();
-})->name('run.deleteAll');
+    $app->controller = $di['runController'];
+    $app->controller->deleteAllForm();
+})->name('run.deleteAll.form');
+
+$app->post('/run/delete_all', function () use ($di, $app) {
+    $di['runController']->deleteAllSubmit();
+})->name('run.deleteAll.submit');
 
 $app->get('/url/view', function () use ($di, $app) {
     $app->controller = $di['runController'];

--- a/src/templates/runs/delete-all-form.twig
+++ b/src/templates/runs/delete-all-form.twig
@@ -1,0 +1,18 @@
+{% extends 'layout/base.twig' %}
+{% import 'macros/helpers.twig' as helpers %}
+
+{% block title %}
+    - Delete all runs
+{% endblock %}
+
+{% block content %}
+<h1>Delete all runs</h1>
+
+<form class="form-stacked" action="{{ url('run.deleteAll.submit') }}" method="post">
+    <div class="hero-unit">
+        <p>Are you sure you want to delete all runs?</p>
+        <input class="btn btn-large btn-danger" type="submit" value="Delete all" />
+    </div>
+</form>
+
+{% endblock %}

--- a/src/templates/runs/list.twig
+++ b/src/templates/runs/list.twig
@@ -10,7 +10,7 @@
 
 {% if runs|length or has_search %}
 <div class="searchbar clearfix">
-    <a href="{{ url('run.deleteAll') }}" class="pull-right btn btn-small delete-all" title="Delete all">
+    <a href="{{ url('run.deleteAll.form') }}" class="pull-right btn btn-small delete-all" title="Delete all">
         <i class="icon-trash"></i> Delete all
     </a>
 

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -193,7 +193,7 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
         $this->assertCount(4, $result['results']);
     }
 
-    public function testDeleteAll()
+    public function testDeleteAllSubmit()
     {
         loadFixture($this->profiles, XHGUI_ROOT_DIR . '/tests/fixtures/results.json');
 
@@ -212,7 +212,7 @@ class Controller_RunTest extends PHPUnit_Framework_TestCase
         $result = $this->profiles->getAll();
         $this->assertCount(5, $result['results']);
 
-        $this->runs->deleteAll();
+        $this->runs->deleteAllSubmit();
 
         $result = $this->profiles->getAll();
         $this->assertCount(0, $result['results']);


### PR DESCRIPTION
* The confirmation form avoids mistakes. It can currently be pressed
  by accident when using a less-than-ideal pointer device, such as
  a touch screen, or keyboard focus.

* The POST verb allows it to be denied or require auth based on
  verb-based server configuration, as was already the case for
  the only other write-method previously (/watch). I'll do
  the same for /run/delete?id in a future commit.

Ref https://github.com/perftools/xhgui/issues/248.