### PR TITLE
Fix false positive PHP 7 job in Travis CI

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -2,7 +2,7 @@
 if [[ "$COVERAGE" == "1" ]]; then
   echo;
   echo "Running unit tests with code-coverage";
-  phpunit --coverage-clover=unittest-coverage.clover
+  composer cover
   echo;
   echo "Uploading code coverage results";
   wget https://scrutinizer-ci.com/ocular.phar
@@ -10,5 +10,5 @@ if [[ "$COVERAGE" == "1" ]]; then
 else
   echo;
   echo "Running unit tests";
-  phpunit
+  composer test
 fi

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
         "phpunit/phpunit": "4.*|5.*",
         "ext-dom": "*"
     },
+    "scripts": {
+        "test": "phpunit",
+        "cover": "phpunit --coverage-clover=unittest-coverage.clover"
+    },
     "suggest": {
         "ext-xhprof": "You need to install either xhprof or uprofiler to use XHGui.",
         "ext-uprofiler": "You need to install either xhprof or uprofiler to use XHGui.",


### PR DESCRIPTION
The job for PHP 7 was passing unconditionally, even when the tests would
fail, such as https://travis-ci.org/perftools/xhgui/builds/475018345.

Turns out this is because phpunit is run directly from the shell
context, where composer/vendor doesn't apply. And Travis CI is
nice enough to bundle a version of phpunit with the environment.

The problem is, that default version of PHPUnit is 6.x on Travis CI
for PHP 7; which no longer recognises the non-namespaces TestCase
classes, and simply prints:

> PHPUnit 6
>
> No tests executed!
>
> The command "bash .travis/run.sh" exited with 0.
> SUCCESS

Fix this by specifying the test in a composer run script, which
is run in a subshell where vendor/bin from Composer is also in
the PATH.

This also makes it easier for developers to run the tests locally
by only having to do `composer install` and `composer test`, which
is a common idiom for PHP-based projects. Previously, one had
to install the correct version globally, or use something like
./vendor/bin/phunit to run the tests.