### PR TITLE
Fix code coverage reporting

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit colors="true" bootstrap="./tests/bootstrap.php">
-    <!-- blacklist the tests and vendor directory from code coverage-->
-    <filter>
-        <blacklist>
-            <directory suffix=".php">./web/vendor</directory>
-        </blacklist>
-    </filter>
-
     <testsuites>
-        <testsuite name="All" suffix="Test.php">
-            <directory>./tests</directory>
+        <testsuite>
+            <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
> [phpunit]
> Error:         Incorrect whitelist config, no code coverage will be generated.

Looks like somewhere along the way, the format for PHPUnit
changed, however, it's not an error that produces a non-zero
exit code, so I missed this.

The ocular.phar command also prints an error, and also without
non-zero exit code, hence making it hard to find when passing.

> [ocular.phar]
> Notifying that no code coverage data is available.