### PR TITLE
Set Cache-Control headers for runs list and runs view

### DIFF
--- a/src/Xhgui/Controller.php
+++ b/src/Xhgui/Controller.php
@@ -36,7 +36,19 @@ abstract class Xhgui_Controller
 
     public function render()
     {
-        $this->app->render($this->_template, $this->_templateVars);
+        // We want to render the specified Twig template to the output buffer.
+        // The simplest way to do that is Slim::render, but that is not allowed
+        // in middleware, because it uses Slim\View::display which prints
+        // directly to the native PHP output buffer.
+        // Doing that is problematic, because the HTTP readers set via $app->response()
+        // must be output first, which won't happen until after the middleware
+        // is completed. Output of headers and body is done by the Slim::run entry point.
+
+        // The below is copied from Slim::render (slim/slim@2.6.3).
+        // Modified to use View::fetch + Response::write, instead of View::display.
+        $this->app->view->appendData($this->_templateVars);
+        $body = $this->app->view->fetch($this->_template);
+        $this->app->response->write($body);
     }
 
 }

--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -22,6 +22,13 @@ class Xhgui_Controller_Run extends Xhgui_Controller
 
     public function index()
     {
+        $response = $this->app->response();
+        // The list changes whenever new profiles are recorded.
+        // Generally avoid caching, but allow re-use in browser's bfcache
+        // and by cache proxies for concurrent requests.
+        // https://github.com/perftools/xhgui/issues/261
+        $response->headers->set('Cache-Control', 'public, max-age=0');
+
         $request = $this->app->request();
 
         $search = array();
@@ -73,6 +80,16 @@ class Xhgui_Controller_Run extends Xhgui_Controller
 
     public function view()
     {
+        $response = $this->app->response();
+        // Permalink views to a specific run are meant to be public and immutable.
+        // But limit the cache to only a short period of time (enough to allow
+        // handling of abuse or other stampedes). This way we don't have to
+        // deal with any kind of purging system for when profiles are deleted,
+        // or for after XHGui itself is upgraded and static assets may be
+        // incompatible etc.
+        // https://github.com/perftools/xhgui/issues/261
+        $response->headers->set('Cache-Control', 'public, max-age=60, must-revalidate');
+
         $request = $this->app->request();
         $detailCount = $this->app->config('detail.count');
         $result = $this->searcher->get($request->get('id'));


### PR DESCRIPTION
Fixes https://github.com/perftools/xhgui/issues/261.

-------

I spent an embarrassingly long time figuring out why the headers were not being output initially. See the inline comment for what the issue turned out to be and how I fixed it.

Long version:
* I tried all four ways in which Slim 2 allows setting of headers (things like `$app->etag()`, `$response['X'] = `, `$response->headers['X'] = `, and `$response->headers->set('X', …)`). None of them worked.
* I tried all those methods from start of the controller method, from the end of the controller method, from the start of the routing callback, and from the end of the routing callback. None of them worked.
* I tried to break it in various ways to verify that indeed there is no caching issue and all relevant code is indeed being executed. It was. But it still didn't work.
* I used `spl_object_hash()` to confirm Slim internally, the router callback, and our controller, are indeed all operating on the same Slim-Response object. They are. But it still didn't work.
* I disabled the controller and wrote to the response directly from the routing callback. 🎉 **Caramba!** Okay, now it works… but why?
* After disabling most everything that the controller does, I narrowed it down to the following innocent one-liner in the Xhgui_Controller middleware: `$this->app->render(…);`
* After tracing recursively everything does this internally in Slim 2.6.3, I noticed it was using `echo` natively to outputs it result. That didn't seem too bad at first, given that from my perspective, we are now well passed the point where we did `$response->headers->set()` which means it should be safe to output directly now.
* Taking a break from the deep dive, and starting another trace from the beginning of the stack; the `Slim::run()` entry point. This loops through the middlewares, then takes the Response object and outputs it status code, headers, and body buffer (in that order). This means middlewares must not write to PHP's output buffer directly, as doing to forces PHP to start the response headers already (which defaults to 200 OK, `text/html`, and basically nothing else). And after that point, no additional headers can be sent.

