### PR TITLE
Skipping built-in functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ return array(
 );
 ```
 
+In addition, if you do not want to profile all PHP built-in functions,
+you can make use of the `profiler.skip_built_in` option.
+
 Profiling a Web Request or CLI script
 =====================================
 

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -86,6 +86,11 @@ return array(
     // NOTE: Only applies to using the external/header.php include.
     'profiler.options' => array(),
 
+    // Whether to profile PHP built-in functions
+    //
+    // NOTE: Only applies to using the external/header.php include.
+    'profiler.skip_built_in' => false,
+
     // Date format used when browsing XHGui pages.
     //
     // Must be a format supported by the PHP date() function.


### PR DESCRIPTION
This patch adds the `profiler.skip_built_in` configuration parameter.
See perftools/xhgui-collector#32 and perftools/xhgui-collector#33