### PR TITLE
env vars for save.handler and pdo

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -17,13 +17,13 @@ return array(
     //     # to reduce locking problems (eg uniqid, time ...)
     //     'save.handler.filename' => __DIR__.'/../data/xhgui_'.date('Ymd').'.dat',
     //
-    'save.handler' => 'mongodb',
+    'save.handler' => getenv('XHGUI_SAVE_HANDLER') ?: 'mongodb',
 
     'pdo' => array(
-        'dsn' => null,
-        'user' => null,
-        'pass' => null,
-        'table' => 'results'
+        'dsn' => getenv('XHGUI_PDO_DSN') ?: null,
+        'user' => getenv('XHGUI_PDO_USER') ?: null,
+        'pass' => getenv('XHGUI_PDO_PASS') ?: null,
+        'table' => getenv('XHGUI_PDO_TABLE') ?: 'results'
     ),
 
     // Database options for MongoDB.


### PR DESCRIPTION
These new environment variables allow to use PDO and a few other save handlers without having to copy & modify the `config.default.php` file. These are specially useful when running XHGUI in Docker.

I've modeled them after the existing `XHGUI_MONGO_HOST` and `XHGUI_MONGO_DATABASE`.

I'm not 100% sure if these changes would be needed (if accepted) in the xhgui-collector.