### PR TITLE
Add an option to exclude environment variables from run view

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "php": "^5.6 || ^7.0",
         "slim/slim": "^2.6.3",
         "slim/views": "^0.1.0",
-        "twig/twig": "~1.17",
+        "twig/twig": "~1.41",
         "pimple/pimple": "^1.0.2",
         "perftools/xhgui-collector": "^1.7.0"
     },

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -44,6 +44,7 @@ return array(
         'Zend*',
         'Composer*',
     ),
+    'run.view.exclude_env_vars' => false,
 
     // Whether to instrument a user request.
     //

--- a/src/Xhgui/Controller/Run.php
+++ b/src/Xhgui/Controller/Run.php
@@ -125,6 +125,7 @@ class Xhgui_Controller_Run extends Xhgui_Controller
             'memory' => $memoryChart,
             'watches' => $watchedFunctions,
             'date_format' => $this->app->config('date.format'),
+            'exclude_env_vars' => $this->app->config('run.view.exclude_env_vars'),
         ));
     }
 

--- a/src/templates/runs/view.twig
+++ b/src/templates/runs/view.twig
@@ -26,7 +26,7 @@
             <li>{{ helpers.property_list('GET', result.meta('get')) }}</li>
 
             <li class="nav-header">SERVER</li>
-            <li>{{ helpers.property_list('SERVER', result.meta('SERVER')) }}
+            <li>{{ helpers.property_list('SERVER', result.meta('SERVER')|filter((v, k) => not exclude_env_vars or result.meta('env')[k] is not defined)) }}</li>
 
             <li class="nav-header">Waterfall</li>
             <li><strong>By IP</strong> <a href="{{ url('waterfall.list', {'remote_addr': result.meta.SERVER.REMOTE_ADDR, 'request_start': result.meta.SERVER.REQUEST_TIME - 5, 'request_end': result.meta.SERVER.REQUEST_TIME + 15}) }}">{{ result.meta.SERVER.REMOTE_ADDR }}</a></li>


### PR DESCRIPTION
Sometimes environment variables contain sensitive data such as passwords and secrets, so I propose to add an option to exclude this data from run view, for example developers can have access to production profiles but have no access to secrets.