### PR TITLE
Add token validation to /run/import handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
+        "ext-json": "*",
         "slim/slim": "^2.6.3",
         "slim/views": "^0.1.0",
         "twig/twig": "~1.17",


### PR DESCRIPTION
When submitting data to `/run/import` add support for token GET parameter, it must match `upload.token` value from config.

Accompanying change in php-profiler:
- https://github.com/perftools/php-profiler/pull/17