### PR TITLE
Incerase client_body_buffer_size to reduce nginx warnings

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,5 +17,7 @@ server {
         fastcgi_pass    app:9000;
         fastcgi_index   index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+
+        client_body_buffer_size 1M;
     }
 }

--- a/src/Xhgui/Controller/Import.php
+++ b/src/Xhgui/Controller/Import.php
@@ -27,7 +27,7 @@ class Xhgui_Controller_Import extends Xhgui_Controller
 
         try {
             $this->runImport($request);
-            $result = ['ok' => true];
+            $result = ['ok' => true, 'size' => $request->getContentLength()];
         } catch (Exception $e) {
             $result = ['error' => true, 'message' => $e->getMessage()];
         }


### PR DESCRIPTION
nginx emits these warnings to logs:

```
 web_1    | 2020-07-11T12:44:05.894779100Z 2020/07/11 12:44:05 [warn] 20#20: *189 a client request body is buffered to a temporary file /var/cache/nginx/client_temp/0000000055, client: 172.23.0.1, server: , request: "POST /run/import?token=token HTTP/1.1", host: "localhost:8142"
```

Just to get rid of the warning, increase the buffer to 1M. My typical payloads are around 512k.

ref:
- https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file