### PR TITLE
Use Alpine Linux image for nginx docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - XHGUI_MONGO_DATABASE=xhprof
 
   web:
-    image: nginx:1
+    image: nginx:1-alpine
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - webroot-share:/var/www/xhgui/webroot


### PR DESCRIPTION
There was no intent to use no-alpine image in https://github.com/perftools/xhgui/pull/263,
just assumption that default nginx image is alpine was wrong.

The obvious upside is smaller image to download:

```
REPOSITORY    TAG           IMAGE ID         CREATED        SIZE
nginx         1-alpine      ecd67fe340f9     16 hours ago   21.6MB
nginx         1             0901fa9da894     16 hours ago   132MB
```