### PR TITLE
[0.19]: Add export to cachegrind format support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "A web based interface for viewing profile data collected by XHProf.",
     "license": "MIT",
     "autoload": {
+        "psr-4": {
+            "Tideways\\Xhprof\\": "src/"
+        },
         "psr-0": {
             "Xhgui_": "src/"
         }

--- a/src/Xhgui/Controller/Export.php
+++ b/src/Xhgui/Controller/Export.php
@@ -21,13 +21,15 @@ class Xhgui_Controller_Export extends Xhgui_Controller
     public function cachegrind()
     {
         $request = $this->app->request();
+        $id = $request->get('id');
+
+        $profile = $this->searcher->get($id);
+        $output = $this->converter->convertToCachegrind($profile->toArray()['profile']);
+
         $response = $this->app->response();
         $response['Content-Type'] = 'application/octet-stream';
         $response['Cache-Control'] = 'public, max-age=60, must-revalidate';
-
-        $profile = $this->searcher->get($request->get('id'));
-        $output = $this->converter->convertToCachegrind($profile->toArray()['profile']);
-
+        $response['Content-Disposition'] = sprintf('attachment; filename=cachegrind-%s.out', $id);
         $response->body($output);
     }
 }

--- a/src/Xhgui/Controller/Export.php
+++ b/src/Xhgui/Controller/Export.php
@@ -1,0 +1,33 @@
+<?php
+
+use Slim\Slim;
+use Tideways\Xhprof\CachegrindConverter;
+
+class Xhgui_Controller_Export extends Xhgui_Controller
+{
+    /** @var CachegrindConverter */
+    private $converter;
+
+    /** @var Xhgui_Searcher_Interface */
+    private $searcher;
+
+    public function __construct(Slim $app, Xhgui_Searcher_Interface $searcher)
+    {
+        parent::__construct($app);
+        $this->searcher = $searcher;
+        $this->converter = new CachegrindConverter();
+    }
+
+    public function cachegrind()
+    {
+        $request = $this->app->request();
+        $response = $this->app->response();
+        $response['Content-Type'] = 'application/octet-stream';
+        $response['Cache-Control'] = 'public, max-age=60, must-revalidate';
+
+        $profile = $this->searcher->get($request->get('id'));
+        $output = $this->converter->convertToCachegrind($profile->toArray()['profile']);
+
+        $response->body($output);
+    }
+}

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -154,6 +154,9 @@ class Xhgui_ServiceContainer extends Pimple
         $this['importController'] = function ($c) {
             return new Xhgui_Controller_Import($c['app'], $c['saver'], $c['config']['upload.token']);
         };
-    }
 
+        $this['exportController'] = function ($c) {
+            return new Xhgui_Controller_Export($c['app'], $c['searcher']);
+        };
+    }
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -88,6 +88,13 @@ $app->post('/run/import', function () use ($di, $app) {
     $controller->import();
 })->name('run.import');
 
+// Export
+$app->get('/export/cachegrind', function () use ($di) {
+    /** @var Xhgui_Controller_Export $controller */
+    $controller = $di['exportController'];
+    $controller->cachegrind();
+})->name('export.cachegrind');
+
 // Watch function routes.
 $app->get('/watch', function () use ($di, $app) {
     $app->controller = $di['watchController'];

--- a/src/templates/runs/view.twig
+++ b/src/templates/runs/view.twig
@@ -21,6 +21,7 @@
             <li><strong>CPU Time</strong> {{ result.get('main()', 'cpu')|as_time }}</li>
             <li><strong>Memory Usage</strong> {{ result.get('main()', 'mu')|as_bytes }}</li>
             <li><strong>Peak Memory Usage</strong> {{ result.get('main()', 'pmu')|as_bytes }}</li>
+            <li><a href="{{ url('export.cachegrind', {id: result.id|trim }) }}"><strong>Download as Cachegrind</strong></a></li>
 
             <li class="nav-header">GET</li>
             <li>{{ helpers.property_list('GET', result.meta('get')) }}</li>


### PR DESCRIPTION
Idea from https://github.com/tideways/php-xhprof-extension/pull/92

---

As the licensing is unknown, you need to download the class manually to src folder:

```
curl -o src/CachegrindConverter.php https://raw.githubusercontent.com/tideways/php-xhprof-extension/Cachegrind/support/src/CachegrindConverter.php
```