### PR TITLE
Update pimple/pimple (v1.1.1 => v3.3.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "slim/slim": "^2.6.3",
         "slim/views": "^0.1.0",
         "twig/twig": "~1.17",
-        "pimple/pimple": "^1.0.2",
+        "pimple/pimple": "^3.3",
         "perftools/xhgui-collector": "^1.7.0"
     },
     "require-dev": {

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -1,12 +1,18 @@
 <?php
+
+use Pimple\Container;
 use Slim\Slim;
 use Slim\Views\Twig;
 use Slim\Middleware\SessionCookie;
 
-class Xhgui_ServiceContainer extends Pimple
+class Xhgui_ServiceContainer extends Container
 {
+    /** @var self */
     protected static $_instance;
 
+    /**
+     * @return self
+     */
     public static function instance()
     {
         if (empty(static::$_instance)) {
@@ -43,7 +49,7 @@ class Xhgui_ServiceContainer extends Pimple
             return $view;
         };
 
-        $this['app'] = $this->share(static function ($c) {
+        $this['app'] = static function ($c) {
             if ($c['config']['timezone']) {
                 date_default_timezone_set($c['config']['timezone']);
             }
@@ -65,7 +71,7 @@ class Xhgui_ServiceContainer extends Pimple
             $app->view($view);
 
             return $app;
-        });
+        };
     }
 
     /**
@@ -75,7 +81,7 @@ class Xhgui_ServiceContainer extends Pimple
     {
         $this['config'] = Xhgui_Config::all();
 
-        $this['db'] = $this->share(static function ($c) {
+        $this['db'] = static function ($c) {
             $config = $c['config'];
             if (empty($config['db.options'])) {
                 $config['db.options'] = [];
@@ -87,15 +93,15 @@ class Xhgui_ServiceContainer extends Pimple
             $mongo->{$config['db.db']}->results->findOne();
 
             return $mongo->{$config['db.db']};
-        });
+        };
 
-        $this['pdo'] = $this->share(static function ($c) {
+        $this['pdo'] = static function ($c) {
             return new PDO(
                 $c['config']['pdo']['dsn'],
                 $c['config']['pdo']['user'],
                 $c['config']['pdo']['pass']
             );
-        });
+        };
 
         $this['searcher.mongo'] = static function ($c) {
             return new Xhgui_Searcher_Mongo($c['db']);
@@ -159,5 +165,4 @@ class Xhgui_ServiceContainer extends Pimple
             return new Xhgui_Controller_Metrics($c['app'], $c['searcher']);
         };
     }
-
 }

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -26,16 +26,12 @@ class ImportTest extends TestCase
         ]);
 
         $di = Xhgui_ServiceContainer::instance();
-        $mock = $this->getMockBuilder(Slim::class)
+        $di['app'] = $this->getMockBuilder(Slim::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
             ->setConstructorArgs([$di['config']])
             ->getMock();
 
-        $di['app'] = $di->share(static function ($c) use ($mock) {
-            return $mock;
-        });
         $this->import = $di['importController'];
-
         $this->profiles = $di['searcher'];
         $this->profiles->truncate();
     }

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -33,14 +33,11 @@ class RunTest extends TestCase
         ]);
 
         $di = Xhgui_ServiceContainer::instance();
-        $mock = $this->getMockBuilder(Slim::class)
+        $di['app'] = $this->getMockBuilder(Slim::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
             ->setConstructorArgs([$di['config']])
             ->getMock();
 
-        $di['app'] = $di->share(static function ($c) use ($mock) {
-            return $mock;
-        });
         $this->import = $di['importController'];
         $this->runs = $di['runController'];
         $this->app = $di['app'];

--- a/tests/Controller/WatchTest.php
+++ b/tests/Controller/WatchTest.php
@@ -25,16 +25,13 @@ class WatchTest extends TestCase
            'SCRIPT_NAME' => 'index.php',
            'PATH_INFO' => '/watch'
         ]);
-        $di = Xhgui_ServiceContainer::instance();
-        unset($di['app']);
 
-        $mock = $this->getMockBuilder(Slim::class)
+        $di = Xhgui_ServiceContainer::instance();
+        $di['app'] = $this->getMockBuilder(Slim::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
             ->setConstructorArgs([$di['config']])
             ->getMock();
-        $di['app'] = $di->share(static function ($c) use ($mock) {
-            return $mock;
-        });
+
         $this->watches = $di['watchController'];
         $this->app = $di['app'];
         $this->searcher = $di['searcher'];


### PR DESCRIPTION
`share()` no longer needed, services are shared by default.

this is pre-requisite for upgrading slim, slim 2.x does not require pimple, but slim 3.x requires pimple 3.x