### PR TITLE
Fixes for Pimple 3 use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "slim/slim": "^2.6.3",
         "slim/views": "^0.1.0",
         "twig/twig": "~1.17",
-        "pimple/pimple": "^3.3"
+        "pimple/pimple": "^3.0"
     },
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -142,28 +142,28 @@ class Xhgui_ServiceContainer extends Container
      */
     protected function _controllers()
     {
-        $this['watchController'] = static function ($c) {
+        $this['watchController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Watch($c['app'], $c['searcher']);
-        };
+        });
 
-        $this['runController'] = static function ($c) {
+        $this['runController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Run($c['app'], $c['searcher']);
-        };
+        });
 
-        $this['customController'] = static function ($c) {
+        $this['customController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Custom($c['app'], $c['searcher']);
-        };
+        });
 
-        $this['waterfallController'] = static function ($c) {
+        $this['waterfallController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Waterfall($c['app'], $c['searcher']);
-        };
+        });
 
-        $this['importController'] = static function ($c) {
+        $this['importController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Import($c['app'], $c['saver'], $c['config']['upload.token']);
-        };
+        });
 
-        $this['metricsController'] = static function ($c) {
+        $this['metricsController'] = $this->factory(static function ($c) {
             return new Xhgui_Controller_Metrics($c['app'], $c['searcher']);
-        };
+        });
     }
 }

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -23,6 +23,7 @@ class Xhgui_ServiceContainer extends Container
 
     public function __construct()
     {
+        parent::__construct();
         $this->_slimApp();
         $this->_services();
         $this->_controllers();


### PR DESCRIPTION
- Allow lower Pimple version for PHP 7.0
- Fix tests: Ensure Run Controller is a factory in the container (otherwise runTest fails because it expects a new instance in each test)
- Add missing parent::__construct for the container (otherwise factories and protected were not initialized)

----

```
- pimple/pimple v3.3.0 requires php ^7.2.5 -> your PHP version (7.0.33) does not satisfy that requirement.
```

refs:
- https://github.com/perftools/xhgui/pull/313