### PR TITLE
Cleanup simple_url twig function

### DIFF
--- a/src/Xhgui/Twig/Extension.php
+++ b/src/Xhgui/Twig/Extension.php
@@ -38,7 +38,6 @@ class Xhgui_Twig_Extension extends Twig_Extension
     public function getFilters()
     {
         return [
-            'simple_url' => new Twig_Filter_Function('Xhgui_Util::simpleUrl'),
             'as_bytes' => new Twig_Filter_Method($this, 'formatBytes', ['is_safe' => ['html']]),
             'as_time' => new Twig_Filter_Method($this, 'formatTime', ['is_safe' => ['html']]),
             'as_diff' => new Twig_Filter_Method($this, 'formatDiff', ['is_safe' => ['html']]),

--- a/src/templates/runs/view.twig
+++ b/src/templates/runs/view.twig
@@ -14,7 +14,7 @@
     <div class="sidebar-nav">
         <ul class="nav nav-list">
             <li class="nav-header">This Run</li>
-            <li><strong>URL</strong> <a href="{{ url('url.view', {'url': result.meta('url')|simple_url }) }}">{{ result.meta('url') }}</a></li>
+            <li><strong>URL</strong> <a href="{{ url('url.view', {'url': result.meta('simple_url') }) }}">{{ result.meta('url') }}</a></li>
             <li><strong>Time</strong> {{ result.date|date(date_format) }}</li>
             <li><strong>ID</strong> <a href="{{ url('custom.help', {id: result.id|trim }) }}">{{ result.id }}</a></li>
             <li><strong>Wall Time</strong> {{ result.get('main()', 'wt')|as_time }}</li>


### PR DESCRIPTION
Use the stored `meta.simple_url` value.

The field has been stored since the function being added in 5a6a359be50a72d033677d8b1d8480d7d4f54f08

Should not calculate it run time, especially as the `simple_url` logic is in collector now.

Fixes https://github.com/perftools/xhgui/issues/318