### PR TITLE
Mongo Saver: Save only known top level keys

### DIFF
--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -19,10 +19,6 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
 
     public function save(array $data)
     {
-        if (!isset($data['_id'])) {
-            $data['_id'] = self::getLastProfilingId();
-        }
-
         if (isset($data['meta']['request_ts'])) {
             $data['meta']['request_ts'] = new MongoDate($data['meta']['request_ts']['sec']);
         }
@@ -34,8 +30,23 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
             );
         }
 
+        $meta = [
+            'url' => $data['meta']['url'],
+            'get' => $data['meta']['get'],
+            'env' => $data['meta']['env'],
+            'SERVER' => $data['meta']['SERVER'],
+            'simple_url' => $data['meta']['simple_url'],
+            'request_ts' => $data['meta']['request_ts'],
+            'request_ts_micro' => $data['meta']['request_ts_micro'],
+            'request_date' => $data['meta']['request_date'],
+        ];
 
-        return $this->_collection->insert($data, array('w' => 0));
+        $a = [
+            '_id' => $data['_id'] ?? self::getLastProfilingId(),
+            'meta' => $meta,
+            'profile' => $data['profile'],
+        ];
+        return $this->_collection->insert($a, ['w' => 0]);
     }
 
     /**

--- a/tests/Saver/MongoTest.php
+++ b/tests/Saver/MongoTest.php
@@ -15,11 +15,14 @@ class MongoTest extends TestCase
         $collection = $this->getMockBuilder(MongoCollection::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $collection->expects($this->once())
+        $collection->expects($this->exactly(5))
             ->method('insert')
-            ->with($this->equalTo($data + ['_id' => Xhgui_Saver_Mongo::getLastProfilingId()]));
+            ->withConsecutive($this->equalTo($data));
 
         $saver = new Xhgui_Saver_Mongo($collection);
-        $saver->save($data);
+
+        foreach ($data as $profile) {
+            $saver->save($profile);
+        }
     }
 }

--- a/tests/fixtures/results.json
+++ b/tests/fixtures/results.json
@@ -7,6 +7,8 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358787612},
+            "request_ts": {"sec": 1358787612, "usec": 0},
+            "request_ts_micro": {"sec": 1358787612, "usec": 123456},
             "request_date": "2013-01-21"
         },
         "profile": {
@@ -34,6 +36,8 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358701212},
+            "request_ts": {"sec": 1358701212, "usec": 0},
+            "request_ts_micro": {"sec": 1358701212, "usec": 123456},
             "request_date": "2013-01-20"
         },
         "profile": {
@@ -96,6 +100,8 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812},
+            "request_ts": {"sec": 1358614812, "usec": 0},
+            "request_ts_micro": {"sec": 1358614812, "usec": 123456},
             "request_date": "2013-01-19"
         },
         "profile": {
@@ -151,6 +157,8 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358528412},
+            "request_ts": {"sec": 1358528412, "usec": 0},
+            "request_ts_micro": {"sec": 1358528412, "usec": 123456},
             "request_date": "2013-01-18"
         },
         "profile": {
@@ -185,6 +193,8 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812},
+            "request_ts": {"sec": 1358614812, "usec": 0},
+            "request_ts_micro": {"sec": 1358614812, "usec": 123456},
             "request_date": "2013-01-19"
         },
         "profile": {


### PR DESCRIPTION
Mongo Saver: Save known top-level keys

This will prevent Upload or File saver submitting totally arbitrary top-level keys.