### PR TITLE
Drop superfluous fields ('request_ts' and 'request_date')

### DIFF
--- a/src/Xhgui/Saver/Mongo.php
+++ b/src/Xhgui/Saver/Mongo.php
@@ -19,16 +19,10 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
 
     public function save(array $data)
     {
-        if (isset($data['meta']['request_ts'])) {
-            $data['meta']['request_ts'] = new MongoDate($data['meta']['request_ts']['sec']);
-        }
-
-        if (isset($data['meta']['request_ts_micro'])) {
-            $data['meta']['request_ts_micro'] = new MongoDate(
-                $data['meta']['request_ts_micro']['sec'],
-                $data['meta']['request_ts_micro']['usec']
-            );
-        }
+        // build 'request_ts' and 'request_date' from 'request_ts_micro'
+        $ts = $data['meta']['request_ts_micro'];
+        $sec = $ts['sec'];
+        $usec = $ts['usec'];
 
         $meta = [
             'url' => $data['meta']['url'],
@@ -36,9 +30,9 @@ class Xhgui_Saver_Mongo implements Xhgui_Saver_Interface
             'env' => $data['meta']['env'],
             'SERVER' => $data['meta']['SERVER'],
             'simple_url' => $data['meta']['simple_url'],
-            'request_ts' => $data['meta']['request_ts'],
-            'request_ts_micro' => $data['meta']['request_ts_micro'],
-            'request_date' => $data['meta']['request_date'],
+            'request_ts' => new MongoDate($sec),
+            'request_ts_micro' => new MongoDate($sec, $usec),
+            'request_date' => date('Y-m-d', $sec),
         ];
 
         $a = [

--- a/src/Xhgui/Saver/Pdo.php
+++ b/src/Xhgui/Saver/Pdo.php
@@ -82,6 +82,11 @@ SQL;
     {
         $main = $data['profile']['main()'];
 
+        // build 'request_ts' and 'request_date' from 'request_ts_micro'
+        $ts = $data['meta']['request_ts_micro'];
+        $sec = $ts['sec'];
+        $usec = $ts['usec'];
+
         $this->stmt->execute(array(
             'id'               => Xhgui_Util::generateId(),
             'profile'          => json_encode($data['profile']),
@@ -90,9 +95,9 @@ SQL;
             'GET'              => json_encode($data['meta']['get']),
             'ENV'              => json_encode($data['meta']['env']),
             'simple_url'       => $data['meta']['simple_url'],
-            'request_ts'       => $data['meta']['request_ts']['sec'],
-            'request_ts_micro' => "{$data['meta']['request_ts_micro']['sec']}.{$data['meta']['request_ts_micro']['usec']}",
-            'request_date'     => $data['meta']['request_date'],
+            'request_ts'       => $sec,
+            'request_ts_micro' => "$sec.$usec",
+            'request_date'     => date('Y-m-d', $sec),
             'main_wt'          => $main['wt'],
             'main_ct'          => $main['ct'],
             'main_cpu'         => $main['cpu'],

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -45,8 +45,6 @@ class ImportTest extends TestCase
                 'get' => [],
                 'env' => [],
                 'SERVER' => ['REQUEST_TIME' => 1358787612],
-                'request_date' => '2013-01-21',
-                'request_ts' => ['sec' => 1358787612, 'usec' => 0],
                 'request_ts_micro' => ['sec' => 1358787612, 'usec' => 123456]
             ],
             'profile' => [

--- a/tests/fixtures/results.json
+++ b/tests/fixtures/results.json
@@ -7,9 +7,7 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358787612},
-            "request_ts": {"sec": 1358787612, "usec": 0},
-            "request_ts_micro": {"sec": 1358787612, "usec": 123456},
-            "request_date": "2013-01-21"
+            "request_ts_micro": {"sec": 1358787612, "usec": 123456}
         },
         "profile": {
             "main()==>strpos()": {
@@ -36,9 +34,7 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358701212},
-            "request_ts": {"sec": 1358701212, "usec": 0},
-            "request_ts_micro": {"sec": 1358701212, "usec": 123456},
-            "request_date": "2013-01-20"
+            "request_ts_micro": {"sec": 1358701212, "usec": 123456}
         },
         "profile": {
             "main()": {
@@ -100,9 +96,7 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812},
-            "request_ts": {"sec": 1358614812, "usec": 0},
-            "request_ts_micro": {"sec": 1358614812, "usec": 123456},
-            "request_date": "2013-01-19"
+            "request_ts_micro": {"sec": 1358614812, "usec": 123456}
         },
         "profile": {
             "main()": {
@@ -157,9 +151,7 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358528412},
-            "request_ts": {"sec": 1358528412, "usec": 0},
-            "request_ts_micro": {"sec": 1358528412, "usec": 123456},
-            "request_date": "2013-01-18"
+            "request_ts_micro": {"sec": 1358528412, "usec": 123456}
         },
         "profile": {
             "main()": {
@@ -193,9 +185,7 @@
             "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812},
-            "request_ts": {"sec": 1358614812, "usec": 0},
-            "request_ts_micro": {"sec": 1358614812, "usec": 123456},
-            "request_date": "2013-01-19"
+            "request_ts_micro": {"sec": 1358614812, "usec": 123456}
         },
         "profile": {
             "main()": {


### PR DESCRIPTION
Build 'request_ts' and 'request_date' from 'request_ts_micro'.

`request_ts` and `request_date` are ignored from now on, they are not needed to be sent over the wire.

_(Extracted out of https://github.com/perftools/xhgui/pull/321)_