### PR TITLE
PDO: Change id column to contain MongoId length

### DIFF
--- a/src/Xhgui/Saver/Pdo.php
+++ b/src/Xhgui/Saver/Pdo.php
@@ -5,7 +5,7 @@ class Xhgui_Saver_Pdo implements Xhgui_Saver_Interface
     const TABLE_DDL = <<<SQL
 
 CREATE TABLE IF NOT EXISTS "%s" (
-  id               TEXT PRIMARY KEY,
+  id               CHAR(24) PRIMARY KEY,
   profile          TEXT           NOT NULL,
   url              TEXT           NULL,
   SERVER           TEXT           NULL,

--- a/src/Xhgui/Util.php
+++ b/src/Xhgui/Util.php
@@ -7,11 +7,16 @@ class Xhgui_Util
      * characters encode the current unix timestamp and the
      * next 16 are random.
      *
-     * @see http://php.net/manual/en/mongodb-bson-objectid.construct.php
+     * The length will always be 24 bytes.
+     * NOTE: The above assumption will fail as the date value will overflow
+     * past Feb 7 06:28:15 2106 UTC and Jan 19 03:14:07 2038 UTC on 32bit
+     * systems
+     *
+     * @see https://php.net/manual/en/mongodb-bson-objectid.construct.php
      *
      * @return string
      */
-    public static function generateId()
+    public static function generateId(): string
     {
         return dechex(time()) . bin2hex(random_bytes(8));
     }


### PR DESCRIPTION
Fixes problem that id is column is too long and not indexed: #322

Changed id column to match MongoId length: 24 characters:
- https://www.php.net/manual/en/mongodb-bson-objectid.construct.php

NOTE: this will break on 2038/2106 year (depending on CPU bits). likely fix is to increase column length to be 26 characters. but deal with the problem when it's due :)