### PR TITLE
PdoSearcher: Use portable LIMIT/OFFSET

### DIFF
--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -192,7 +192,7 @@ class PdoSearcher implements SearcherInterface
           FROM {$this->table}
           WHERE simple_url LIKE :url
           ORDER BY request_ts DESC
-          LIMIT $skip, $perPage
+          LIMIT $skip OFFSET $perPage
         ");
         $stmt->execute(['url' => '%'.$url.'%']);
 


### PR DESCRIPTION
Use `LIMIT x OFFSET y` instead of `LIMIT x, y` for pgsql:
- https://github.com/perftools/xhgui/issues/322#issuecomment-692404334

thx @lauripiisang for https://github.com/perftools/xhgui/pull/332#issuecomment-696645703