### PR TITLE
Fix RunTest::testIndexWithSearch for Pdo searcher

### DIFF
--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -191,7 +191,7 @@ class PdoSearcher implements SearcherInterface
             "main_pmu"
           FROM "' . $this->table . '"
           WHERE "simple_url" LIKE :url
-          ORDER BY "request_ts" DESC
+          ORDER BY "request_ts" ' . $direction. '
           LIMIT ' . $skip . ' OFFSET ' . $perPage);
         $stmt->execute(['url' => '%'.$url.'%']);
 
@@ -224,7 +224,7 @@ class PdoSearcher implements SearcherInterface
         return [
             'results' => $results,
             'sort' => 'meta.request_ts',
-            'direction' => 'desc',
+            'direction' => $direction,
             'page' => $page,
             'perPage' => $perPage,
             'totalPages' => $totalPages,


### PR DESCRIPTION
It expects direction parameter passed by:

```
2) XHGui\Test\Controller\RunTest::testIndexWithSearch
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'asc'
+'desc'
```

this includes one fix to backends disparity:
- https://github.com/perftools/xhgui/issues/320