### PR TITLE
Add Pdo saver/searcher tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 env:
   - XHGUI_SAVE_HANDLER=mongodb
   - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="mysql:host=localhost;dbname=xhgui" XHGUI_PDO_USER=root
+  - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="sqlite:/tmp/xhgui.sqlite3"
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
 
 services:
   - mongodb
+  - mysql
 
 install:
   - .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
 
 env:
   - XHGUI_SAVE_HANDLER=mongodb
-  - XHGUI_SAVE_HANDLER=pdo
+  - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="mysql:host=localhost;dbname=xhgui" XHGUI_PDO_USER=root
 
 jobs:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ php:
   - 7.1
   - 7.0
 
+env:
+  - XHGUI_SAVE_HANDLER=mongodb
+  - XHGUI_SAVE_HANDLER=pdo
+
 jobs:
   allow_failures:
     - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - XHGUI_SAVE_HANDLER=mongodb
   - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="mysql:host=localhost;dbname=xhgui" XHGUI_PDO_USER=root
   - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="sqlite:/tmp/xhgui.sqlite3"
+  - XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="pgsql:dbname=xhgui user=postgres password="
 
 jobs:
   allow_failures:
@@ -27,6 +28,7 @@ jobs:
 services:
   - mongodb
   - mysql
+  - postgresql
 
 install:
   - .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
 jobs:
   allow_failures:
     - php: 7.4
+    # Allow pdo jobs to fail. Env match must be exact
+    # https://docs.travis-ci.com/user/build-matrix/#excluding-jobs-with-env-value
+    - env: XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="mysql:host=localhost;dbname=xhgui" XHGUI_PDO_USER=root
+    - env: XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="sqlite:/tmp/xhgui.sqlite3"
+    - env: XHGUI_SAVE_HANDLER=pdo XHGUI_PDO_DSN="pgsql:dbname=xhgui user=postgres password="
   include:
     - php: 7.2
       env: COVERAGE=1

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -15,6 +15,9 @@ case "$XHGUI_SAVE_HANDLER:$XHGUI_PDO_DSN" in
 pdo:mysql:*)
     mysql -uroot -e "create database xhgui"
     ;;
+pdo:pgsql:*)
+    psql -c 'create database xhgui;' -U postgres
+    ;;
 esac
 
 composer install --prefer-dist

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,11 +1,21 @@
 #!/bin/bash -e
 
-if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then
-	# installed, but not enabled?
-	echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-else
-    php -m | grep -q mongodb || pecl install -f mongodb
-fi
+install_mongodb() {
+    if [[ "$TRAVIS_PHP_VERSION" == "7.2" ]]; then
+        # installed, but not enabled?
+        echo "extension = mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    else
+        php -m | grep -q mongodb || pecl install -f mongodb
+    fi
+}
+
+install_mongodb
+
+case "$XHGUI_SAVE_HANDLER:$XHGUI_PDO_DSN" in
+pdo:mysql:*)
+    mysql -uroot -e "create database xhgui"
+    ;;
+esac
 
 composer install --prefer-dist
 chmod -R 0777 cache/


### PR DESCRIPTION
The PDO tests are broken in various ways.

Actually fixing tests will be an incremental process, so they are marked in allow failure.

While PDO tests should not require MongoDB, tests, and dependencies are broken that makes it still required.