### PR TITLE
PdoSaver: Allow _id override for unit testing

### DIFF
--- a/src/Xhgui/Saver/MongoSaver.php
+++ b/src/Xhgui/Saver/MongoSaver.php
@@ -42,24 +42,11 @@ class MongoSaver implements SaverInterface
         ];
 
         $a = [
-            '_id' => $data['_id'] ?? self::getLastProfilingId(),
+            '_id' => $data['_id'] ?? new MongoId(),
             'meta' => $meta,
             'profile' => $data['profile'],
         ];
 
         return $this->_collection->insert($a, ['w' => 0]);
-    }
-
-    /**
-     * Return profiling ID
-     * @return MongoId lastProfilingId
-     */
-    public static function getLastProfilingId()
-    {
-        if (!self::$lastProfilingId) {
-            self::$lastProfilingId = new MongoId();
-        }
-
-        return self::$lastProfilingId;
     }
 }

--- a/src/Xhgui/Saver/PdoSaver.php
+++ b/src/Xhgui/Saver/PdoSaver.php
@@ -94,7 +94,7 @@ SQL;
         $usec = $ts['usec'];
 
         $this->stmt->execute([
-            'id'               => Util::generateId(),
+            'id'               => $data['_id'] ?? Util::generateId(),
             'profile'          => json_encode($data['profile']),
             'url'              => $data['meta']['url'],
             'SERVER'           => json_encode($data['meta']['SERVER']),


### PR DESCRIPTION
Similarly in MongoSaver:
- https://github.com/perftools/xhgui/commit/93ca56f2083278dbd70355c016278933246876b4

refs:
- https://github.com/perftools/xhgui-collector/pull/11

this includes a fix to backends disparity:
- https://github.com/perftools/xhgui/issues/320