### PR TITLE
Allow overriding saver id only via id parameter

### DIFF
--- a/src/Xhgui/Controller/RunController.php
+++ b/src/Xhgui/Controller/RunController.php
@@ -167,7 +167,7 @@ class RunController extends AbstractController
     {
         $id = $request->post('id');
         // Don't call profilers->delete() unless $id is set,
-        // otherwise it will turn the null into a MongoId and return "Sucessful".
+        // otherwise it will turn the null into a MongoId and return "Successful".
         if (!is_string($id) || !strlen($id)) {
             // Form checks this already,
             // only reachable by handcrafted or malformed requests.

--- a/src/Xhgui/Saver/MongoSaver.php
+++ b/src/Xhgui/Saver/MongoSaver.php
@@ -36,15 +36,14 @@ class MongoSaver implements SaverInterface
             'request_date' => date('Y-m-d', $sec),
         ];
 
-        $id = $id ?? new MongoId();
         $a = [
-            '_id' => $id,
+            '_id' => new MongoId($id),
             'meta' => $meta,
             'profile' => $data['profile'],
         ];
 
         $this->_collection->insert($a, ['w' => 0]);
 
-        return (string)$id;
+        return (string)$a['_id'];
     }
 }

--- a/src/Xhgui/Saver/MongoSaver.php
+++ b/src/Xhgui/Saver/MongoSaver.php
@@ -18,7 +18,7 @@ class MongoSaver implements SaverInterface
         $this->_collection = $collection;
     }
 
-    public function save(array $data): string
+    public function save(array $data, string $id = null): string
     {
         // build 'request_ts' and 'request_date' from 'request_ts_micro'
         $ts = $data['meta']['request_ts_micro'];
@@ -36,7 +36,7 @@ class MongoSaver implements SaverInterface
             'request_date' => date('Y-m-d', $sec),
         ];
 
-        $id = $data['_id'] ?? new MongoId();
+        $id = $id ?? new MongoId();
         $a = [
             '_id' => $id,
             'meta' => $meta,

--- a/src/Xhgui/Saver/PdoSaver.php
+++ b/src/Xhgui/Saver/PdoSaver.php
@@ -16,7 +16,7 @@ class PdoSaver implements SaverInterface
         $this->db = $db;
     }
 
-    public function save(array $data): string
+    public function save(array $data, string $id = null): string
     {
         $main = $data['profile']['main()'];
 
@@ -25,7 +25,7 @@ class PdoSaver implements SaverInterface
         $sec = $ts['sec'];
         $usec = $ts['usec'];
 
-        $id = $data['_id'] ?? Util::generateId();
+        $id = $id ?? Util::generateId();
         $this->db->saveProfile([
             'id' => $id,
             'profile' => json_encode($data['profile']),

--- a/src/Xhgui/Saver/SaverInterface.php
+++ b/src/Xhgui/Saver/SaverInterface.php
@@ -7,5 +7,5 @@ interface SaverInterface
     /**
      * Returns id of the saved profile
      */
-    public function save(array $data): string;
+    public function save(array $data, string $id = null): string;
 }

--- a/tests/Saver/MongoTest.php
+++ b/tests/Saver/MongoTest.php
@@ -22,7 +22,7 @@ class MongoTest extends TestCase
         $saver = new MongoSaver($collection);
 
         foreach ($data as $profile) {
-            $saver->save($profile);
+            $saver->save($profile, $profile['_id'] ?? null);
         }
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,13 +25,6 @@ function loadFixture(SaverInterface $saver, $file)
 {
     $data = json_decode(file_get_contents($file), true);
     foreach ($data as $record) {
-        if (isset($record['meta']['request_time'])) {
-            $time = strtotime($record['meta']['request_time']);
-            $record['meta']['request_time'] = new MongoDate($time);
-        }
-        if (isset($record['_id'])) {
-            $record['_id'] = new MongoId($record['_id']);
-        }
         $saver->save($record, $record['_id'] ?? null);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,6 +32,6 @@ function loadFixture(SaverInterface $saver, $file)
         if (isset($record['_id'])) {
             $record['_id'] = new MongoId($record['_id']);
         }
-        $saver->save($record);
+        $saver->save($record, $record['_id'] ?? null);
     }
 }


### PR DESCRIPTION
Id from saver is ignored, the only way to set id (for testing) is via an extra parameter to `save()`.

refs:
- https://github.com/perftools/php-profiler/issues/39