### PR TITLE
Encode dot in MongoDB saver as underscore

### DIFF
--- a/src/Xhgui/Saver/MongoSaver.php
+++ b/src/Xhgui/Saver/MongoSaver.php
@@ -40,11 +40,34 @@ class MongoSaver implements SaverInterface
         $a = [
             '_id' => $id,
             'meta' => $meta,
-            'profile' => $data['profile'],
+            'profile' => $this->encodeProfile($data['profile']),
         ];
 
         $this->_collection->insert($a, ['w' => 0]);
 
         return (string)$id;
+    }
+
+    /**
+     * MongoDB can't save keys with values containing a dot:
+     *
+     *   InvalidArgumentException: invalid document for insert: keys cannot contain ".":
+     *   "Zend_Controller_Dispatcher_Standard::loadClass==>load::controllers/ArticleController.php"
+     *
+     * Replace the dots with underscrore in keys.
+     *
+     * @link https://github.com/perftools/xhgui/issues/209
+     */
+    private function encodeProfile(array $profile): array
+    {
+        $results = [];
+        foreach ($profile as $k => $v) {
+            if (strpos($k, '.') !== false) {
+                $k = str_replace('.', '_', $k);
+            }
+            $results[$k] = $v;
+        }
+
+        return $results;
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/perftools/xhgui/issues/209
- Replaces https://github.com/perftools/xhgui/pull/210

Decided to use ASCII `_` instead of Unicode values to avoid further surprises. And the value is used just for display purposes, so doesn't matter what it really is.