### PR TITLE
Allow external/import.php to be included into docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,6 +3,7 @@
 /*
 !/composer.*
 !/config/
+!/external/
 !/src/
 !/vendor/
 !/webroot/

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN composer install $COMPOSER_FLAGS --no-scripts --no-autoloader
 
 # copy rest of the project. copy in order that is least to most changed
 COPY --from=source /app/webroot ./webroot
+COPY --from=source /app/external ./external
 COPY --from=source /app/src ./src
 COPY --from=source /app/config ./config
 


### PR DESCRIPTION
Someone may want to run the script inside the container, so package for that to be possible.