### PR TITLE
Add default direction (asc) for pdo searcher

### DIFF
--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -99,7 +99,7 @@ class PdoSearcher implements SearcherInterface
     public function getAll($options = [])
     {
         $page = (int)$options['page'];
-        $direction = $options['direction'];
+        $direction = $options['direction'] ?? 'asc';
         if ($page < 1) {
             $page = 1;
         }


### PR DESCRIPTION
refs:
- https://github.com/perftools/xhgui/issues/349#issuecomment-712771122

bugfix:
- https://github.com/perftools/xhgui/pull/351