### PR TITLE
Initialize schema on PdoRepository creation

### DIFF
--- a/src/Xhgui/Db/PdoRepository.php
+++ b/src/Xhgui/Db/PdoRepository.php
@@ -22,6 +22,7 @@ class PdoRepository
     {
         $this->pdo = $pdo;
         $this->table = sprintf('"%s"', $table);
+        $this->initSchema();
     }
 
     public function getLatest(): array

--- a/src/Xhgui/Saver/PdoSaver.php
+++ b/src/Xhgui/Saver/PdoSaver.php
@@ -12,7 +12,6 @@ class PdoSaver implements SaverInterface
 
     public function __construct(PdoRepository $db)
     {
-        $db->initSchema();
         $this->db = $db;
     }
 


### PR DESCRIPTION
This fixes the problem that if no saves have been recorded the listing throws
fatal error with PDO storage.

In the future, the table init could be perhaps created lazily:
- https://github.com/perftools/xhgui/issues/349#issuecomment-712761263