### PR TITLE
Use same default direction for pdo/mongodb

### DIFF
--- a/src/Xhgui/Db/Mapper.php
+++ b/src/Xhgui/Db/Mapper.php
@@ -5,6 +5,7 @@ namespace XHGui\Db;
 use DateInterval;
 use DateTime;
 use MongoDate;
+use XHGui\Searcher\SearcherInterface;
 
 class Mapper
 {
@@ -114,7 +115,7 @@ class Mapper
     protected function _direction($options)
     {
         if (empty($options['direction'])) {
-            return 'desc';
+            return SearcherInterface::DEFAULT_DIRECTION;
         }
         $valid = ['desc', 'asc'];
         if (in_array($options['direction'], $valid, true)) {

--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -99,7 +99,7 @@ class PdoSearcher implements SearcherInterface
     public function getAll($options = [])
     {
         $page = (int)$options['page'];
-        $direction = $options['direction'] ?? 'asc';
+        $direction = $options['direction'] ?? SearcherInterface::DEFAULT_DIRECTION;
         if ($page < 1) {
             $page = 1;
         }

--- a/src/Xhgui/Searcher/SearcherInterface.php
+++ b/src/Xhgui/Searcher/SearcherInterface.php
@@ -11,6 +11,8 @@ use XHGui\Profile;
  */
 interface SearcherInterface
 {
+    const DEFAULT_DIRECTION = 'desc';
+
     /**
      * Get the latest profile data.
      *


### PR DESCRIPTION
This fixes failing test:

```
2) XHGui\Test\Controller\RunTest::testIndexEmpty
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'total_pages' => 1
     'page' => 1
     'sort' => null
-    'direction' => 'desc'
+    'direction' => 'asc'
```