### PR TITLE
Normalize profiler record, fill missing keys

### DIFF
--- a/external/import.php
+++ b/external/import.php
@@ -31,7 +31,11 @@ while (!feof($fp)) {
     $line = fgets($fp);
     $data = json_decode($line, true);
     if ($data) {
-        $saver->save($data);
+        try {
+            $saver->save($data);
+        } catch (Throwable $e) {
+            error_log($e);
+        }
     }
 }
 fclose($fp);

--- a/src/Xhgui/Profile.php
+++ b/src/Xhgui/Profile.php
@@ -54,6 +54,14 @@ class Profile
         $result = [];
         foreach ($this->_data['profile'] as $name => $values) {
             list($parent, $func) = $this->splitName($name);
+            // normalize, fill all missing keys
+            $values += [
+                'ct' => 0,
+                'wt' => 0,
+                'cpu' => 0,
+                'mu' => 0,
+                'pmu' => 0,
+            ];
 
             // Generate collapsed data.
             if (isset($result[$func])) {

--- a/src/Xhgui/Saver/NormalizingSaver.php
+++ b/src/Xhgui/Saver/NormalizingSaver.php
@@ -2,6 +2,8 @@
 
 namespace XHGui\Saver;
 
+use RuntimeException;
+
 class NormalizingSaver implements SaverInterface
 {
     private $saver;
@@ -14,6 +16,12 @@ class NormalizingSaver implements SaverInterface
     public function save(array $data, string $id = null): string
     {
         foreach ($data['profile'] as $index => &$profile) {
+            // skip empty profilings
+            if (!$profile) {
+                unset($data['profile'][$index]);
+                continue;
+            }
+
             // normalize, fill all missing keys
             $profile += [
                 'ct' => 0,
@@ -22,6 +30,11 @@ class NormalizingSaver implements SaverInterface
                 'mu' => 0,
                 'pmu' => 0,
             ];
+        }
+        unset($profile);
+
+        if (!$data['profile']) {
+            throw new RuntimeException("Skipping to save empty profiling");
         }
 
         return $this->saver->save($data, $id);

--- a/src/Xhgui/Saver/NormalizingSaver.php
+++ b/src/Xhgui/Saver/NormalizingSaver.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace XHGui\Saver;
+
+class NormalizingSaver implements SaverInterface
+{
+    private $saver;
+
+    public function __construct(SaverInterface $saver)
+    {
+        $this->saver = $saver;
+    }
+
+    public function save(array $data, string $id = null): string
+    {
+        foreach ($data['profile'] as $index => &$profile) {
+            // normalize, fill all missing keys
+            $profile += [
+                'ct' => 0,
+                'wt' => 0,
+                'cpu' => 0,
+                'mu' => 0,
+                'pmu' => 0,
+            ];
+        }
+
+        return $this->saver->save($data, $id);
+    }
+}

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -12,6 +12,7 @@ use Slim\Slim as App;
 use Slim\Views\Twig;
 use XHGui\Db\PdoRepository;
 use XHGui\Middleware\RenderMiddleware;
+use XHGui\Saver\NormalizingSaver;
 use XHGui\Searcher\MongoSearcher;
 use XHGui\Searcher\PdoSearcher;
 use XHGui\Twig\TwigExtension;
@@ -168,7 +169,7 @@ class ServiceContainer extends Container
         $this['saver'] = static function ($c) {
             $saver = $c['config']['save.handler'];
 
-            return $c["saver.$saver"];
+            return new NormalizingSaver($c["saver.$saver"]);
         };
     }
 


### PR DESCRIPTION
This allows profilings without cpu and memory metrics.

Replaces: https://github.com/perftools/xhgui/pull/344
Fixes: https://github.com/perftools/xhgui/issues/343, https://github.com/perftools/xhgui/issues/146