### PR TITLE
PDO: Fix swapped limit and offset parameters

### DIFF
--- a/src/Xhgui/Db/PdoRepository.php
+++ b/src/Xhgui/Db/PdoRepository.php
@@ -118,8 +118,8 @@ class PdoRepository
           LIMIT %d OFFSET %d',
             $this->table,
             $direction,
-            $skip,
-            $perPage
+            $perPage,
+            $skip
         );
         $stmt = $this->pdo->prepare($query);
         $stmt->execute(['url' => '%' . $url . '%']);


### PR DESCRIPTION
This got broken in 414c95b8 refactoring (https://github.com/perftools/xhgui/pull/340).

Fixes https://github.com/perftools/xhgui/issues/371