### PR TITLE
Import: require input to be parsed properly

### DIFF
--- a/src/Xhgui/Controller/ImportController.php
+++ b/src/Xhgui/Controller/ImportController.php
@@ -53,6 +53,9 @@ class ImportController extends AbstractController
         }
 
         $data = json_decode($request->getBody(), true);
+        if (!is_array($data)) {
+            throw new InvalidArgumentException('Failed do decode payload');
+        }
 
         return $this->saver->save($data);
     }


### PR DESCRIPTION
Do not call saver if input is not in expected format (array).

Fixes ugly error given in response:

```
<br />
<b>Fatal error</b>:  Uncaught TypeError: Argument 1 passed to XHGui\Saver\MongoSaver::save() must be of the type array, null given, called in /var/www/xhgui/src/Xhgui/Controller/ImportController.php on line 57 and defined in /var/www/xhgui/src/Xhgui/Saver/MongoSaver.php:21
Stack trace:
#0 /var/www/xhgui/src/Xhgui/Controller/ImportController.php(57): XHGui\Saver\MongoSaver-&gt;save(NULL)
#1 /var/www/xhgui/src/Xhgui/Controller/ImportController.php(33): XHGui\Controller\ImportController-&gt;runImport(Object(Slim\Http\Request))
#2 /var/www/xhgui/src/routes.php(150): XHGui\Controller\ImportController-&gt;import(Object(Slim\Http\Request), Object(Slim\Http\Response))
#3 [internal function]: {closure}()
#4 /var/www/xhgui/vendor/slim/slim/Slim/Route.php(468): call_user_func_array(Object(Closure), Array)
#5 /var/www/xhgui/vendor/slim/slim/Slim/Slim.php(1355): Slim\Route-&gt;dispatch()
#6 /var/www/xhgui/vendor/slim/slim/Slim/Middleware/Flash.php(85): Slim\Slim-&gt;call()
#7 /var/www/xhgui/vendor/slim/slim/Slim/Middleware/MethodOverride.php(92): Slim\Middl in <b>/var/www/xhgui/src/Xhgui/Saver/MongoSaver.php</b> on line <b>21</b><br />
```