### PR TITLE
Move MongoDB config under "mongodb" subkey

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -18,13 +18,6 @@ return [
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',
     ],
 
-    // If defined, add imports via upload (/run/import) must pass token parameter with this value
-    'upload.token' => getenv('XHGUI_UPLOAD_TOKEN') ?: '',
-
-    // Add this path prefix to all links and resources
-    // If this is not defined, auto-detection will try to find it itself
-    'path.prefix' => null,
-
     // Database options for MongoDB.
     //
     // - db.host: Connection string in the form `mongodb://[ip or host]:[port]`.
@@ -44,6 +37,13 @@ return [
         'Zend*',
         'Composer*',
     ],
+
+    // If defined, add imports via upload (/run/import) must pass token parameter with this value
+    'upload.token' => getenv('XHGUI_UPLOAD_TOKEN') ?: '',
+
+    // Add this path prefix to all links and resources
+    // If this is not defined, auto-detection will try to find it itself
+    'path.prefix' => null,
 
     // Setup timezone for date formatting
     // Example: 'UTC', 'Europe/Tallinn'

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -11,6 +11,7 @@ return [
     // Must be one of 'mongodb', or 'pdo'.
     'save.handler' => getenv('XHGUI_SAVE_HANDLER') ?: 'mongodb',
 
+    // Database options for PDO.
     'pdo' => [
         'dsn' => getenv('XHGUI_PDO_DSN') ?: null,
         'user' => getenv('XHGUI_PDO_USER') ?: null,
@@ -19,19 +20,21 @@ return [
     ],
 
     // Database options for MongoDB.
-    //
-    // - db.host: Connection string in the form `mongodb://[ip or host]:[port]`.
-    //
-    // - db.db: The database name.
-    //
-    // - db.options: Additional options for the MongoClient contructor,
-    //               for example 'username', 'password', or 'replicaSet'.
-    //               See <https://secure.php.net/mongoclient_construct#options>.
-    //
-    'db.host' => getenv('XHGUI_MONGO_HOST') ?: 'mongodb://127.0.0.1:27017',
-    'db.db' => getenv('XHGUI_MONGO_DATABASE') ?: 'xhprof',
-    'db.options' => [],
-    'db.driverOptions' => [],
+    'mongodb' => [
+        // 'hostname' and 'port' are used to build DSN for MongoClient
+        'hostname' => getenv('XHGUI_MONGO_HOSTNAME') ?: '127.0.0.1',
+        'port' => getenv('XHGUI_MONGO_PORT') ?: 27017,
+        // The database name
+        'database' => getenv('XHGUI_MONGO_DATABASE') ?: 'xhprof',
+        // Additional options for the MongoClient constructor,
+        // for example 'username', 'password', or 'replicaSet'.
+        // See <https://www.php.net/mongoclient_construct#options>.
+        'options' => [],
+        // An array of options for the MongoDB driver.
+        // Options include setting connection context options for SSL or logging callbacks.
+        // See <https://www.php.net/mongoclient_construct#options>.
+        'driverOptions' => [],
+    ],
 
     'run.view.filter.names' => [
         'Zend*',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - webroot-share:/var/www/xhgui/webroot
       - ./config:/var/www/xhgui/config
     environment:
-      - XHGUI_MONGO_HOST=mongodb://mongo:27017
+      - XHGUI_MONGO_HOSTNAME=mongo
       - XHGUI_MONGO_DATABASE=xhprof
 
   web:

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -104,10 +104,12 @@ class ServiceContainer extends Container
 
         $this['db'] = static function ($c) {
             $database = $c['mongo.database'];
+            /** @var MongoClient $client */
             $client = $c[MongoClient::class];
-            $client->{$database}->results->findOne();
+            $mongoDB = $client->selectDb($database);
+            $mongoDB->results->findOne();
 
-            return $client->{$database};
+            return $mongoDB;
         };
 
         $this[MongoClient::class] = static function ($c) {
@@ -172,10 +174,10 @@ class ServiceContainer extends Container
         };
 
         $this['saver.mongodb'] = static function ($c) {
-            $mongo = $c[MongoClient::class];
+            /** @var MongoClient $client */
+            $client = $c[MongoClient::class];
             $database = $c['mongo.database'];
-
-            $collection = $mongo->{$database}->results;
+            $collection = $client->selectDb($database)->results;
             $collection->findOne();
 
             return new Saver\MongoSaver($collection);

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -159,9 +159,14 @@ class ServiceContainer extends Container
     private function storageDriverMongoDb(Container $app)
     {
         // NOTE: db.host, db.options, db.driverOptions, db.db are @deprecated and will be removed in the future
-        $app[MongoDB::class] = static function ($app) {
+        $app['mongodb.database'] = static function ($app) {
             $config = $app['config'];
-            $database = $config['db.db'] ?? $mongodb['database'] ?? 'xhgui';
+
+            return $config['db.db'] ?? $mongodb['database'] ?? 'xhgui';
+        };
+
+        $app[MongoDB::class] = static function ($app) {
+            $database = $app['mongodb.database'];
             /** @var MongoClient $client */
             $client = $app[MongoClient::class];
             $mongoDB = $client->selectDb($database);

--- a/src/Xhgui/ServiceContainer.php
+++ b/src/Xhgui/ServiceContainer.php
@@ -97,16 +97,17 @@ class ServiceContainer extends Container
 
         $this['db'] = static function ($c) {
             $config = $c['config'];
-            if (empty($config['db.options'])) {
-                $config['db.options'] = [];
-            }
-            if (empty($config['db.driverOptions'])) {
-                $config['db.driverOptions'] = [];
-            }
-            $mongo = new MongoClient($config['db.host'], $config['db.options'], $config['db.driverOptions']);
-            $mongo->{$config['db.db']}->results->findOne();
+            // NOTE: db.host, db.options, db.driverOptions, db.db are @deprecated and will be removed in the future
+            $mongodb = $config['mongodb'] ?? [];
+            $options = $config['db.options'] ?? $mongodb['options'] ?? [];
+            $driverOptions = $config['db.driverOptions'] ?? $mongodb['driverOptions'] ?? [];
+            $database = $config['db.db'] ?? $mongodb['database'] ?? 'xhgui';
+            $server = $config['db.host'] ?? sprintf('mongodb://%s:%s', $mongodb['hostname'], $mongodb['port']);
 
-            return $mongo->{$config['db.db']};
+            $client = new MongoClient($server, $options, $driverOptions);
+            $client->{$database}->results->findOne();
+
+            return $client->{$database};
         };
 
         $this['pdo'] = static function ($c) {

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -2,6 +2,7 @@
 
 namespace XHGui\Test\Searcher;
 
+use MongoDB;
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
 use XHGui\Searcher\MongoSearcher;
@@ -22,7 +23,7 @@ class MongoTest extends TestCase
         $di = ServiceContainer::instance();
         $this->mongo = $di['searcher.mongodb'];
 
-        $di['db']->watches->drop();
+        $di[MongoDB::class]->watches->drop();
 
         $this->loadFixture($di['saver.mongodb']);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,10 +9,9 @@ require dirname(__DIR__) . '/src/bootstrap.php';
 
 $di = ServiceContainer::instance();
 
-// Use a test database.
-$config = $di['config'];
-$config['db.db'] = 'test_' . $config['db.db'];
-$di['config'] = $config;
+// Use a test databases
+$di['mongodb.database'] = 'test_xhgui';
+// TODO: do the same for PDO. currently PDO uses DSN syntax and has too many variations
 
 // Clean up globals.
 unset($di, $config);


### PR DESCRIPTION
New mongodb config keys:

```php
    'mongodb' => [
        // 'hostname' and 'port' are used to build DSN for MongoClient
        'hostname' => getenv('XHGUI_MONGO_HOSTNAME') ?: '127.0.0.1',
        'port' => getenv('XHGUI_MONGO_PORT') ?: 27017,
        // The database name
        'database' => getenv('XHGUI_MONGO_DATABASE') ?: 'xhprof',
        // Additional options for the MongoClient constructor,
        // for example 'username', 'password', or 'replicaSet'.
        // See <https://www.php.net/mongoclient_construct#options>.
        'options' => [],
        // An array of options for the MongoDB driver.
        // Options include setting connection context options for SSL or logging callbacks.
        // See <https://www.php.net/mongoclient_construct#options>.
        'driverOptions' => [],
    ],
```

Support for previous keys remains for undefined future.

Fixes https://github.com/perftools/xhgui/issues/267