### PR TITLE
PDO: Throw exception instead if silently failing

### DIFF
--- a/src/Xhgui/Exception/NotImplementedException.php
+++ b/src/Xhgui/Exception/NotImplementedException.php
@@ -6,4 +6,8 @@ use RuntimeException;
 
 class NotImplementedException extends RuntimeException
 {
+    public static function notImplementedPdo(string $method): self
+    {
+        throw new self(sprintf('%s not implemented for PDO', $method));
+    }
 }

--- a/src/Xhgui/Exception/NotImplementedException.php
+++ b/src/Xhgui/Exception/NotImplementedException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace XHGui\Exception;
+
+use RuntimeException;
+
+class NotImplementedException extends RuntimeException
+{
+}

--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -3,6 +3,7 @@
 namespace XHGui\Searcher;
 
 use XHGui\Db\PdoRepository;
+use XHGui\Exception\NotImplementedException;
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
 
@@ -39,12 +40,9 @@ class PdoSearcher implements SearcherInterface
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function query($conditions, $limit, $fields = [])
     {
-        // TODO: Implement query() method.
+        throw NotImplementedException::notImplementedPdo(__METHOD__);
     }
 
     /**
@@ -70,20 +68,14 @@ class PdoSearcher implements SearcherInterface
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getForUrl($url, $options, $conditions = [])
     {
-        // TODO: Implement getForUrl() method.
+        throw NotImplementedException::notImplementedPdo(__METHOD__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPercentileForUrl($percentile, $url, $search = [])
     {
-        // TODO: Implement getPercentileForUrl() method.
+        throw NotImplementedException::notImplementedPdo(__METHOD__);
     }
 
     /**
@@ -91,7 +83,7 @@ class PdoSearcher implements SearcherInterface
      */
     public function getAvgsForUrl($url, $search = [])
     {
-        // TODO: Implement getAvgsForUrl() method.
+        throw NotImplementedException::notImplementedPdo(__METHOD__);
     }
 
     /**


### PR DESCRIPTION
An apparently a simple view like http://xhgui.127.0.0.1.xip.io:8142/url/view?url=%2Fview.php%3Fid returned null type, which on PHP 7.4 results accessing null as an array and is an error.

This is call developers: implement (even partial) support rather than returning wrong types (`null`).