### PR TITLE
Setup actions/cache@v2 for CI

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -32,8 +32,21 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mongodb
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
       - name: Install dependencies
-        run: composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run PHPUnit tests
         run: composer test

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -38,8 +38,21 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: pdo, pdo_mysql
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
       - name: Install dependencies
-        run: composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run PHPUnit tests
         run: composer test

--- a/.github/workflows/tests-pgsql.yml
+++ b/.github/workflows/tests-pgsql.yml
@@ -37,8 +37,21 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: pdo, pdo_pgsql
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
       - name: Install dependencies
-        run: composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run PHPUnit tests
         run: composer test

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -26,8 +26,21 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: pdo, pdo_sqlite
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
       - name: Install dependencies
-        run: composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run PHPUnit tests
         run: composer test


### PR DESCRIPTION
No need to install composer dependencies from lock if they have not changed. Should decrease egress/ingress of CI.