### PR TITLE
Tests: Use ocramius/lazy-property to delay db connections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "glen/php-cs-fixer-config": "^0.3.0",
+        "ocramius/lazy-property": "^1.0",
         "phpunit/phpunit": "^5.7.27 | ^6.5.13"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "551d596307af7e264baf5b407fe9f1e8",
+    "content-hash": "c270a58bf3464f32cc1afbeffc2ad22a",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -668,6 +668,59 @@
                 "object graph"
             ],
             "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "ocramius/lazy-property",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/LazyProperty.git",
+                "reference": "6ebe14852b08a89d28c064a75ea88dbe88dad07c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/LazyProperty/zipball/6ebe14852b08a89d28c064a75ea88dbe88dad07c",
+                "reference": "6ebe14852b08a89d28c064a75ea88dbe88dad07c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.4|~7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0",
+                "squizlabs/php_codesniffer": "~2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "LazyProperty\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                }
+            ],
+            "description": "A library that provides lazy instantiation logic for object properties",
+            "homepage": "https://github.com/Ocramius/LazyProperty",
+            "keywords": [
+                "lazy",
+                "lazy instantiation",
+                "lazy loading",
+                "utility"
+            ],
+            "time": "2016-01-21T16:19:39+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/src/Xhgui/Searcher/MongoSearcher.php
+++ b/src/Xhgui/Searcher/MongoSearcher.php
@@ -220,12 +220,11 @@ class MongoSearcher implements SearcherInterface
         $this->_collection->remove(['_id' => new MongoId($id)], []);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function truncate()
     {
-        return $this->_collection->drop();
+        $this->_collection->drop();
+
+        return $this;
     }
 
     /**
@@ -275,12 +274,11 @@ class MongoSearcher implements SearcherInterface
         return array_values(iterator_to_array($cursor));
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function truncateWatches()
     {
         $this->_watches->drop();
+
+        return $this;
     }
 
     /**

--- a/src/Xhgui/Searcher/PdoSearcher.php
+++ b/src/Xhgui/Searcher/PdoSearcher.php
@@ -147,12 +147,11 @@ class PdoSearcher implements SearcherInterface
         $this->db->deleteById($id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function truncate()
     {
-        return $this->db->deleteAll();
+        $this->db->deleteAll();
+
+        return $this;
     }
 
     /**
@@ -176,6 +175,7 @@ class PdoSearcher implements SearcherInterface
      */
     public function truncateWatches()
     {
+        return $this;
     }
 
     /**

--- a/src/Xhgui/Searcher/SearcherInterface.php
+++ b/src/Xhgui/Searcher/SearcherInterface.php
@@ -105,7 +105,7 @@ interface SearcherInterface
      *
      * Primarily used in test cases to reset the test db.
      *
-     * @return bool
+     * @return self
      */
     public function truncate();
 
@@ -129,6 +129,8 @@ interface SearcherInterface
 
     /**
      * Truncate the watch collection.
+     *
+     * @return self
      */
     public function truncateWatches();
 

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -20,8 +20,6 @@ class ImportTest extends TestCase
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
-
-        $this->searcher->truncate();
     }
 
     public function testImportSuccess()
@@ -52,12 +50,13 @@ class ImportTest extends TestCase
             'slim.input' => json_encode($data),
         ]);
 
-        $before = $this->searcher->getForUrl('/things', []);
+        $searcher = $this->searcher->truncate();
+        $before = $searcher->getForUrl('/things', []);
         $this->assertEmpty($before['results']);
 
         $this->import->import($this->app->request(), $this->app->response());
 
-        $after = $this->searcher->getForUrl('/things', []);
+        $after = $searcher->getForUrl('/things', []);
         $this->assertNotEmpty($after['results']);
         $this->assertInstanceOf(Profile::class, $after['results'][0]);
     }

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -21,7 +21,7 @@ class ImportTest extends TestCase
             'PATH_INFO' => '/',
         ]);
 
-        $this->profiles->truncate();
+        $this->searcher->truncate();
     }
 
     public function testImportSuccess()
@@ -52,12 +52,12 @@ class ImportTest extends TestCase
             'slim.input' => json_encode($data),
         ]);
 
-        $before = $this->profiles->getForUrl('/things', []);
+        $before = $this->searcher->getForUrl('/things', []);
         $this->assertEmpty($before['results']);
 
         $this->import->import($this->app->request(), $this->app->response());
 
-        $after = $this->profiles->getForUrl('/things', []);
+        $after = $this->searcher->getForUrl('/things', []);
         $this->assertNotEmpty($after['results']);
         $this->assertInstanceOf(Profile::class, $after['results'][0]);
     }

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -4,37 +4,29 @@ namespace XHGui\Test\Controller;
 
 use Slim\Environment;
 use Slim\Slim as App;
-use XHGui\Controller\ImportController;
 use XHGui\Profile;
-use XHGui\Searcher\SearcherInterface;
-use XHGui\ServiceContainer;
+use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class ImportTest extends TestCase
 {
-    /** @var SearcherInterface */
-    private $profiles;
-    /** @var ImportController */
-    private $import;
-    /** @var App */
-    private $app;
+    use LazyContainerProperties;
 
     public function setUp()
     {
         parent::setUp();
+        $this->setupProperties();
+
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
 
-        $di = ServiceContainer::instance();
-        $this->app = $di['app'] = $this->getMockBuilder(App::class)
+        $this->app = $this->di['app'] = $this->getMockBuilder(App::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$di['config']])
+            ->setConstructorArgs([$this->di['config']])
             ->getMock();
 
-        $this->import = $di['importController'];
-        $this->profiles = $di['searcher'];
         $this->profiles->truncate();
     }
 

--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -3,7 +3,6 @@
 namespace XHGui\Test\Controller;
 
 use Slim\Environment;
-use Slim\Slim as App;
 use XHGui\Profile;
 use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
@@ -21,11 +20,6 @@ class ImportTest extends TestCase
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
-
-        $this->app = $this->di['app'] = $this->getMockBuilder(App::class)
-            ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$this->di['config']])
-            ->getMock();
 
         $this->profiles->truncate();
     }

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -4,47 +4,30 @@ namespace XHGui\Test\Controller;
 
 use Slim\Environment;
 use Slim\Slim as App;
-use XHGui\Controller\ImportController;
-use XHGui\Controller\RunController;
 use XHGui\Options\SearchOptions;
-use XHGui\Saver\MongoSaver;
-use XHGui\Searcher\MongoSearcher;
-use XHGui\ServiceContainer;
+use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class RunTest extends TestCase
 {
-    /** @var RunController */
-    private $runs;
-    /** @var MongoSaver */
-    private $saver;
-    /** @var App */
-    private $app;
-    /** @var MongoSearcher */
-    private $profiles;
-    /** @var ImportController */
-    private $import;
+    use LazyContainerProperties;
 
     public function setUp()
     {
         parent::setUp();
+        $this->setupProperties();
+
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
 
-        $di = ServiceContainer::instance();
-        $di['app'] = $this->getMockBuilder(App::class)
+        $this->di['app'] = $this->getMockBuilder(App::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$di['config']])
+            ->setConstructorArgs([$this->di['config']])
             ->getMock();
 
-        $this->import = $di['importController'];
-        $this->runs = $di['runController'];
-        $this->app = $di['app'];
-        $this->profiles = $di['searcher'];
         $this->profiles->truncate();
-        $this->saver = $di['saver'];
     }
 
     public function testIndexEmpty()

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -20,8 +20,6 @@ class RunTest extends TestCase
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
-
-        $this->searcher->truncate();
     }
 
     public function testIndexEmpty()
@@ -137,6 +135,7 @@ class RunTest extends TestCase
 
     public function testCallgraph()
     {
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',
@@ -153,6 +152,7 @@ class RunTest extends TestCase
 
     public function testCallgraphData()
     {
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',
@@ -170,6 +170,7 @@ class RunTest extends TestCase
     public function testDeleteSubmit()
     {
         $this->skipIfPdo('Undefined index: page');
+        $searcher = $this->searcher->truncate();
         $this->loadFixture($this->saver);
 
         Environment::mock([
@@ -188,18 +189,19 @@ class RunTest extends TestCase
         $this->app->expects($this->once())
             ->method('redirect');
 
-        $result = $this->searcher->getAll(new SearchOptions());
+        $result = $searcher->getAll(new SearchOptions());
         $this->assertCount(5, $result['results']);
 
         $this->runs->deleteSubmit($this->app->request());
 
-        $result = $this->searcher->getAll(new SearchOptions());
+        $result = $searcher->getAll(new SearchOptions());
         $this->assertCount(4, $result['results']);
     }
 
     public function testDeleteAllSubmit()
     {
         $this->skipIfPdo('Undefined index: page');
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
 
         Environment::mock([
@@ -225,6 +227,7 @@ class RunTest extends TestCase
 
     public function testFilterCustomMethods()
     {
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
 
         Environment::mock([
@@ -241,6 +244,7 @@ class RunTest extends TestCase
 
     public function testFilterCustomMethod()
     {
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
 
         Environment::mock([
@@ -257,6 +261,7 @@ class RunTest extends TestCase
 
     public function testFilterMethods()
     {
+        $this->searcher->truncate();
         $this->loadFixture($this->saver);
 
         Environment::mock([

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -21,7 +21,7 @@ class RunTest extends TestCase
             'PATH_INFO' => '/',
         ]);
 
-        $this->profiles->truncate();
+        $this->searcher->truncate();
     }
 
     public function testIndexEmpty()
@@ -188,12 +188,12 @@ class RunTest extends TestCase
         $this->app->expects($this->once())
             ->method('redirect');
 
-        $result = $this->profiles->getAll(new SearchOptions());
+        $result = $this->searcher->getAll(new SearchOptions());
         $this->assertCount(5, $result['results']);
 
         $this->runs->deleteSubmit($this->app->request());
 
-        $result = $this->profiles->getAll(new SearchOptions());
+        $result = $this->searcher->getAll(new SearchOptions());
         $this->assertCount(4, $result['results']);
     }
 
@@ -214,12 +214,12 @@ class RunTest extends TestCase
         $this->app->expects($this->once())
           ->method('redirect');
 
-        $result = $this->profiles->getAll(new SearchOptions());
+        $result = $this->searcher->getAll(new SearchOptions());
         $this->assertCount(5, $result['results']);
 
         $this->runs->deleteAllSubmit();
 
-        $result = $this->profiles->getAll(new SearchOptions());
+        $result = $this->searcher->getAll(new SearchOptions());
         $this->assertCount(0, $result['results']);
     }
 

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -3,7 +3,6 @@
 namespace XHGui\Test\Controller;
 
 use Slim\Environment;
-use Slim\Slim as App;
 use XHGui\Options\SearchOptions;
 use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
@@ -21,11 +20,6 @@ class RunTest extends TestCase
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/',
         ]);
-
-        $this->di['app'] = $this->getMockBuilder(App::class)
-            ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$this->di['config']])
-            ->getMock();
 
         $this->profiles->truncate();
     }

--- a/tests/Controller/WatchTest.php
+++ b/tests/Controller/WatchTest.php
@@ -20,12 +20,11 @@ class WatchTest extends TestCase
            'SCRIPT_NAME' => 'index.php',
            'PATH_INFO' => '/watch',
         ]);
-
-        $this->searcher->truncateWatches();
     }
 
     public function testGet()
     {
+        $this->searcher->truncateWatches();
         $this->watches->get();
         $result = $this->watches->templateVars();
         $this->assertEquals([], $result['watched']);
@@ -33,6 +32,7 @@ class WatchTest extends TestCase
 
     public function testPostAdd()
     {
+        $this->searcher->truncateWatches();
         $_POST = [
             'watch' => [
                 ['name' => 'strlen'],
@@ -56,8 +56,9 @@ class WatchTest extends TestCase
 
     public function testPostModify()
     {
-        $this->searcher->saveWatch(['name' => 'strlen']);
-        $saved = $this->searcher->getAllWatches();
+        $searcher = $this->searcher->truncateWatches();
+        $searcher->saveWatch(['name' => 'strlen']);
+        $saved = $searcher->getAllWatches();
 
         $_POST = [
             'watch' => [
@@ -65,7 +66,7 @@ class WatchTest extends TestCase
             ],
         ];
         $this->watches->post($this->app->request());
-        $result = $this->searcher->getAllWatches();
+        $result = $searcher->getAllWatches();
 
         $this->assertCount(1, $result);
         $this->assertEquals('strpos', $result[0]['name']);
@@ -73,6 +74,7 @@ class WatchTest extends TestCase
 
     public function testPostDelete()
     {
+        $this->searcher->truncateWatches();
         $this->searcher->saveWatch(['name' => 'strlen']);
         $saved = $this->searcher->getAllWatches();
 

--- a/tests/Controller/WatchTest.php
+++ b/tests/Controller/WatchTest.php
@@ -4,39 +4,29 @@ namespace XHGui\Test\Controller;
 
 use Slim\Environment;
 use Slim\Slim as App;
-use XHGui\Controller\WatchController;
-use XHGui\Searcher\SearcherInterface;
-use XHGui\ServiceContainer;
+use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class WatchTest extends TestCase
 {
-    /** @var WatchController */
-    private $watches;
-    /** @var App */
-    private $app;
-    /** @var SearcherInterface */
-    private $searcher;
+    use LazyContainerProperties;
 
     public function setUp()
     {
         $this->skipIfPdo('Watchers not implemented');
-
         parent::setUp();
+        $this->setupProperties();
+
         Environment::mock([
            'SCRIPT_NAME' => 'index.php',
            'PATH_INFO' => '/watch',
         ]);
 
-        $di = ServiceContainer::instance();
-        $di['app'] = $this->getMockBuilder(App::class)
+        $this->di['app'] = $this->getMockBuilder(App::class)
             ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$di['config']])
+            ->setConstructorArgs([$this->di['config']])
             ->getMock();
 
-        $this->watches = $di['watchController'];
-        $this->app = $di['app'];
-        $this->searcher = $di['searcher'];
         $this->searcher->truncateWatches();
     }
 

--- a/tests/Controller/WatchTest.php
+++ b/tests/Controller/WatchTest.php
@@ -3,7 +3,6 @@
 namespace XHGui\Test\Controller;
 
 use Slim\Environment;
-use Slim\Slim as App;
 use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
@@ -21,11 +20,6 @@ class WatchTest extends TestCase
            'SCRIPT_NAME' => 'index.php',
            'PATH_INFO' => '/watch',
         ]);
-
-        $this->di['app'] = $this->getMockBuilder(App::class)
-            ->setMethods(['redirect', 'render', 'urlFor'])
-            ->setConstructorArgs([$this->di['config']])
-            ->getMock();
 
         $this->searcher->truncateWatches();
     }

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -52,7 +52,13 @@ trait LazyContainerProperties
 
     protected function getDi()
     {
-        return ServiceContainer::instance();
+        $di = ServiceContainer::instance();
+        $di['app'] = $this->getMockBuilder(App::class)
+            ->setMethods(['redirect', 'render', 'urlFor'])
+            ->setConstructorArgs([$di['config']])
+            ->getMock();
+
+        return $di;
     }
 
     protected function getApp()

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -3,6 +3,13 @@
 namespace XHGui\Test;
 
 use LazyProperty\LazyPropertiesTrait;
+use Slim\Slim as App;
+use XHGui\Controller\ImportController;
+use XHGui\Controller\RunController;
+use XHGui\Controller\WatchController;
+use XHGui\Saver\MongoSaver;
+use XHGui\Searcher\MongoSearcher;
+use XHGui\Searcher\SearcherInterface;
 use XHGui\ServiceContainer;
 
 trait LazyContainerProperties
@@ -11,16 +18,81 @@ trait LazyContainerProperties
 
     /** @var ServiceContainer */
     protected $di;
+    /** @var ImportController */
+    protected $import;
+    /** @var MongoSearcher */
+    private $mongo;
+    /** @var RunController */
+    protected $runs;
+    /** @var App */
+    protected $app;
+    /** @var MongoSearcher */
+    protected $profiles;
+    /** @var SearcherInterface */
+    protected $searcher;
+    /** @var MongoSaver */
+    protected $saver;
+    /** @var WatchController */
+    protected $watches;
 
     protected function setupProperties()
     {
         $this->initLazyProperties([
             'di',
+            'app',
+            'import',
+            'mongo',
+            'profiles',
+            'runs',
+            'saver',
+            'searcher',
+            'watches',
         ]);
     }
 
     protected function getDi()
     {
         return ServiceContainer::instance();
+    }
+
+    protected function getApp()
+    {
+        return $this->di['app'];
+    }
+
+    protected function getImport()
+    {
+        return $this->di['importController'];
+    }
+
+    protected function getMongo()
+    {
+        return $this->di['searcher.mongodb'];
+    }
+
+    /** @deprecated */
+    protected function getProfiles()
+    {
+        return $this->searcher;
+    }
+
+    protected function getSearcher()
+    {
+        return $this->di['searcher'];
+    }
+
+    protected function getRuns()
+    {
+        return $this->di['runController'];
+    }
+
+    protected function getSaver()
+    {
+        return $this->di['saver'];
+    }
+
+    protected function getWatches()
+    {
+        return $this->di['watchController'];
     }
 }

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -26,8 +26,6 @@ trait LazyContainerProperties
     protected $runs;
     /** @var App */
     protected $app;
-    /** @var MongoSearcher */
-    protected $profiles;
     /** @var SearcherInterface */
     protected $searcher;
     /** @var MongoSaver */
@@ -42,7 +40,6 @@ trait LazyContainerProperties
             'app',
             'import',
             'mongo',
-            'profiles',
             'runs',
             'saver',
             'searcher',
@@ -74,12 +71,6 @@ trait LazyContainerProperties
     protected function getMongo()
     {
         return $this->di['searcher.mongodb'];
-    }
-
-    /** @deprecated */
-    protected function getProfiles()
-    {
-        return $this->searcher;
     }
 
     protected function getSearcher()

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace XHGui\Test;
+
+use LazyProperty\LazyPropertiesTrait;
+use XHGui\ServiceContainer;
+
+trait LazyContainerProperties
+{
+    use LazyPropertiesTrait;
+
+    /** @var ServiceContainer */
+    protected $di;
+
+    protected function setupProperties()
+    {
+        $this->initLazyProperties([
+            'di',
+        ]);
+    }
+
+    protected function getDi()
+    {
+        return ServiceContainer::instance();
+    }
+}

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -5,8 +5,6 @@ namespace XHGui\Test\Searcher;
 use MongoDB;
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
-use XHGui\Searcher\MongoSearcher;
-use XHGui\ServiceContainer;
 use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -7,25 +7,21 @@ use XHGui\Options\SearchOptions;
 use XHGui\Profile;
 use XHGui\Searcher\MongoSearcher;
 use XHGui\ServiceContainer;
+use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class MongoTest extends TestCase
 {
-    /**
-     * @var MongoSearcher
-     */
-    private $mongo;
+    use LazyContainerProperties;
 
     public function setUp()
     {
+        parent::setUp();
+        $this->setupProperties();
+
         $this->skipIfPdo('This is MongoDB test');
-
-        $di = ServiceContainer::instance();
-        $this->mongo = $di['searcher.mongodb'];
-
-        $di[MongoDB::class]->watches->drop();
-
-        $this->loadFixture($di['saver.mongodb']);
+        $this->di[MongoDB::class]->watches->drop();
+        $this->loadFixture($this->di['saver.mongodb']);
     }
 
     public function testCustomQuery()


### PR DESCRIPTION
Using lazy init, can delay database connection when needed.
This prevents DB connection be made in `setUp()` even if the test is to be skipped.
Minimizes creating of connections, that are maybe even not needed.

AS there have appeared weird postgresql errors:
- https://github.com/perftools/xhgui/runs/1584096943
  - https://github.com/shivammathur/setup-php/issues/378