### PR TITLE
Add nginx to docker base image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,11 @@ services:
   xhgui:
     image: xhgui/xhgui:0.17.1
     volumes:
-      - webroot-share:/var/www/xhgui/webroot
       - ./config:/var/www/xhgui/config
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     environment:
       - XHGUI_MONGO_HOSTNAME=mongo
       - XHGUI_MONGO_DATABASE=xhprof
-
-  web:
-    image: nginx:1-alpine
-    volumes:
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - webroot-share:/var/www/xhgui/webroot
     ports:
       - "8142:80"
 


### PR DESCRIPTION
This drops separate `nginx` container, and therefore avoids the need to synchronize data with `fpm` and `nginx` container with webroot volume.

The webroot volume is a source of annoyance when its content changes.
need to prune the volume to catch up updates from it.

For the end-users, they needed to stop containers, remove `xhgui_webroot-share` docker volume manually.

- Cleanup: www-data group is provided by nginx package
- Add volume for nginx pid
- Launch nginx before fpm
- Link nginx logs to stdout/stderr

Note: This switches `php-fpm` user to `www-data` (was mistakenly `nobody`).

```
/var/www/xhgui # ps axwuf
PID   USER     TIME  COMMAND
    1 root      0:00 php-fpm: master process (/etc/php7/php-fpm.conf)
    8 root      0:00 nginx: master process nginx
    9 nginx     0:00 nginx: worker process
   10 nginx     0:00 nginx: worker process
   11 nginx     0:00 nginx: worker process
   12 nginx     0:00 nginx: worker process
   13 www-data  0:01 php-fpm: pool www
   14 www-data  0:00 php-fpm: pool www
/var/www/xhgui #
```