### PR TITLE
Drop SessionCookie middleware

### DIFF
--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -9,7 +9,6 @@ use MongoDB\Driver\Manager;
 use PDO;
 use Pimple\Container;
 use RuntimeException;
-use Slim\Middleware\SessionCookie;
 use Slim\Slim as App;
 use Slim\Views\Twig;
 use XHGui\Db\PdoRepository;
@@ -92,11 +91,6 @@ class ServiceContainer extends Container
             }
 
             $app = new App($c['config']);
-
-            // Enable cookie based sessions
-            $app->add(new SessionCookie([
-                'httponly' => true,
-            ]));
 
             $view = $c['view'];
             $view->parserExtensions = [


### PR DESCRIPTION
It was added in 0041530a017bc651d891a33f378d13d4ae07de0d

I believe it's no used, therefore dropping to ease Slim v3 migration.