### PR TITLE
Saver: Drop "get" key requirement from profiler data on submit

### DIFF
--- a/src/Saver/NormalizingSaver.php
+++ b/src/Saver/NormalizingSaver.php
@@ -15,6 +15,13 @@ class NormalizingSaver implements SaverInterface
 
     public function save(array $data, string $id = null): string
     {
+        // extract "get" from "url"
+        // profiler no longer needs to send "get" over the wire.
+        // the individual savers may choose not to store this down separately
+        $query = parse_url($data['meta']['url'], PHP_URL_QUERY);
+        parse_str($query, $get);
+        $data['meta']['get'] = $get;
+
         foreach ($data['profile'] as $index => &$profile) {
             // skip empty profilings
             if (!$profile) {

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -190,12 +190,12 @@ class RunTest extends TestCase
             ->method('redirect');
 
         $result = $searcher->getAll(new SearchOptions());
-        $this->assertCount(7, $result['results']);
+        $count = count($result['results']);
 
         $this->runs->deleteSubmit($this->app->request());
 
         $result = $searcher->getAll(new SearchOptions());
-        $this->assertCount(6, $result['results']);
+        $this->assertCount($count - 1, $result['results']);
     }
 
     public function testDeleteAllSubmit(): void
@@ -217,7 +217,7 @@ class RunTest extends TestCase
           ->method('redirect');
 
         $result = $this->searcher->getAll(new SearchOptions());
-        $this->assertCount(7, $result['results']);
+        $this->assertGreaterThan(0, count($result['results']));
 
         $this->runs->deleteAllSubmit();
 

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -138,7 +138,7 @@ class MongoTest extends TestCase
     {
         $result = $this->mongo->latest();
         $this->assertInstanceOf(Profile::class, $result);
-        $this->assertEquals('2013-01-21', $result->getDate()->format('Y-m-d'));
+        $this->assertEquals('2020-04-18', $result->getDate()->format('Y-m-d'));
     }
 
     public function testSaveInsert(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /**
      * Load a fixture into the database.
      */
-    protected function importFixture(SaverInterface $saver, string $fileName = 'results.json'): void
+    protected function importFixture(SaverInterface $saver, string $fileName = 'normalized.json'): void
     {
         foreach ($this->loadFixture($fileName) as $record) {
             $saver->save($record, $record['_id'] ?? null);

--- a/tests/fixtures/normalized.json
+++ b/tests/fixtures/normalized.json
@@ -4,7 +4,9 @@
         "meta": {
             "url": "/tasks?page=3",
             "simple_url": "/tasks",
-            "get": [],
+            "get": {
+                "page": "3"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358787612, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358787612, "usec": 123456}
@@ -31,7 +33,9 @@
         "meta": {
             "url": "/tasks?page=2",
             "simple_url": "/tasks",
-            "get": [],
+            "get": {
+                "page": "2"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358701212, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358701212, "usec": 123456}
@@ -93,7 +97,9 @@
         "meta": {
             "url": "/tasks?page=1",
             "simple_url": "/tasks",
-            "get": [],
+            "get": {
+                "page": "1"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}
@@ -148,7 +154,9 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
+            "get": {
+                "page": "1"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358528412, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358528412, "usec": 123456}
@@ -182,7 +190,9 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
+            "get": {
+                "page": "1"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}
@@ -202,7 +212,9 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
+            "get": {
+                "page": "1"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}
@@ -223,7 +235,9 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
+            "get": {
+                "page": "1"
+            },
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}

--- a/tests/fixtures/normalized.json
+++ b/tests/fixtures/normalized.json
@@ -251,5 +251,33 @@
                 "pmu": 3001
             }
         }
+    },
+    {
+        "_id": "aaaaaaaaaaaaaaaaaaaaaab1",
+        "meta": {
+            "url": "phpunit-7.5.phar --configuration phpunit.xml",
+            "get": [],
+            "env": [],
+            "SERVER": {
+                "PHP_SELF": "/usr/local/bin/phpunit-7.5.phar",
+                "DOCUMENT_ROOT": "",
+                "REQUEST_TIME_FLOAT": 1587223926.187821,
+                "REQUEST_TIME": 1587223926
+            },
+            "simple_url": "phpunit-7.5.phar --configuration phpunit.xml",
+            "request_ts_micro": {
+                "sec": "1587223926",
+                "usec": "1878"
+            }
+        },
+        "profile": {
+            "main()": {
+                "ct": 1,
+                "wt": 127,
+                "cpu": 0,
+                "mu": 0,
+                "pmu": 0
+            }
+        }
     }
 ]

--- a/tests/fixtures/results.json
+++ b/tests/fixtures/results.json
@@ -231,5 +231,30 @@
                 "pmu": 3001
             }
         }
+    },
+    {
+        "_id": "aaaaaaaaaaaaaaaaaaaaaab1",
+        "meta": {
+            "url": "phpunit-7.5.phar --configuration phpunit.xml",
+            "get": [],
+            "env": [],
+            "SERVER": {
+                "PHP_SELF": "/usr/local/bin/phpunit-7.5.phar",
+                "DOCUMENT_ROOT": "",
+                "REQUEST_TIME_FLOAT": 1587223926.187821,
+                "REQUEST_TIME": 1587223926
+            },
+            "simple_url": "phpunit-7.5.phar --configuration phpunit.xml",
+            "request_ts_micro": {
+                "sec": "1587223926",
+                "usec": "1878"
+            }
+        },
+        "profile": {
+            "main()": {
+                "ct": 1,
+                "wt": 127
+            }
+        }
     }
 ]

--- a/tests/fixtures/results.json
+++ b/tests/fixtures/results.json
@@ -4,7 +4,6 @@
         "meta": {
             "url": "/tasks?page=3",
             "simple_url": "/tasks",
-            "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358787612, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358787612, "usec": 123456}
@@ -31,7 +30,6 @@
         "meta": {
             "url": "/tasks?page=2",
             "simple_url": "/tasks",
-            "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358701212, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358701212, "usec": 123456}
@@ -93,7 +91,6 @@
         "meta": {
             "url": "/tasks?page=1",
             "simple_url": "/tasks",
-            "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}
@@ -148,7 +145,6 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358528412, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358528412, "usec": 123456}
@@ -182,7 +178,6 @@
         "meta": {
             "url": "/?page=1",
             "simple_url": "/",
-            "get": [],
             "env": [],
             "SERVER": {"REQUEST_TIME": 1358614812, "SERVER_NAME": "localhost", "REQUEST_METHOD": "GET"},
             "request_ts_micro": {"sec": 1358614812, "usec": 123456}


### PR DESCRIPTION
Drop "get" key from profiler data when it's submitted. The value is now extracted from "url", so sending "get" data is redundant.

Profiler no longer needs to send "get" over the wire.
The individual savers may choose not to store this down separately.