### PR TITLE
MongoSearcher - preserve indexes on truncate

### DIFF
--- a/src/Searcher/MongoSearcher.php
+++ b/src/Searcher/MongoSearcher.php
@@ -222,7 +222,7 @@ class MongoSearcher implements SearcherInterface
 
     public function truncate()
     {
-        $this->_collection->drop();
+        $this->_collection->remove();
 
         return $this;
     }
@@ -276,7 +276,7 @@ class MongoSearcher implements SearcherInterface
 
     public function truncateWatches()
     {
-        $this->_watches->drop();
+        $this->_watches->remove();
 
         return $this;
     }

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -3,6 +3,7 @@
 namespace XHGui\Test;
 
 use LazyProperty\LazyPropertiesTrait;
+use MongoDB;
 use Slim\Slim as App;
 use Slim\View;
 use XHGui\Controller\ImportController;
@@ -24,6 +25,8 @@ trait LazyContainerProperties
     protected $import;
     /** @var MongoSearcher */
     private $mongo;
+    /** @var MongoDB */
+    protected $mongodb;
     /** @var RunController */
     protected $runs;
     /** @var App */
@@ -44,6 +47,7 @@ trait LazyContainerProperties
             'app',
             'import',
             'mongo',
+            'mongodb',
             'runs',
             'saver',
             'searcher',
@@ -88,6 +92,11 @@ trait LazyContainerProperties
     protected function getMongo()
     {
         return $this->di['searcher.mongodb'];
+    }
+
+    protected function getMongoDb()
+    {
+        return $this->di[MongoDB::class];
     }
 
     protected function getSearcher()

--- a/tests/Searcher/MongoHelper.php
+++ b/tests/Searcher/MongoHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace XHGui\Test\Searcher;
+
+use ArrayIterator;
+use MongoDB;
+use MultipleIterator;
+
+class MongoHelper
+{
+    /** @var MongoDB */
+    private $mongodb;
+    /** @var array */
+    private $indexes = [];
+
+    public function __construct(MongoDB $mongodb)
+    {
+        $this->mongodb = $mongodb;
+    }
+
+    public function dropCollection(string $collectionName): void
+    {
+        $collection = $this->mongodb->selectCollection($collectionName);
+        $collection->drop();
+    }
+
+    public function createCollection(string $collectionName, array $indexes): void
+    {
+        $collection = $this->mongodb->createCollection($collectionName);
+
+        foreach ($indexes as [$keys, $options]) {
+            $collection->createIndex($keys, $options);
+        }
+        $this->indexes[$collectionName] = $indexes;
+    }
+
+    public function getIndexes(string $collectionName): MultipleIterator
+    {
+        $collection = $this->mongodb->selectCollection($collectionName);
+        $expectedIndexes = $this->indexes[$collectionName];
+
+        $resultIndexInfo = $collection->getIndexInfo();
+        $resultIndexes = array_column($resultIndexInfo, 'key');
+        $resultIndexNames = array_column($resultIndexInfo, 'name');
+
+        $iterator = new MultipleIterator();
+        $iterator->attachIterator(new ArrayIterator($resultIndexes));
+        $iterator->attachIterator(new ArrayIterator($resultIndexNames));
+        $iterator->attachIterator(new ArrayIterator($expectedIndexes));
+
+        return $iterator;
+    }
+}

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -188,7 +188,7 @@ class MongoTest extends TestCase
 
     public function testTruncateResultsPreserveIndexes(): void
     {
-        $mongoDb = $this->getDi()[MongoDB::class];
+        $mongoDb = $this->mongodb;
         $collection = $mongoDb->results;
 
         // dropping "results" collection using raw client
@@ -252,7 +252,7 @@ class MongoTest extends TestCase
 
     public function testTruncateWatchesPreserveIndexes(): void
     {
-        $mongoDb = $this->getDi()[MongoDB::class];
+        $mongoDb = $this->mongodb;
         $collection = $mongoDb->watches;
 
         // dropping "watches" collection using raw client


### PR DESCRIPTION
### Description
When truncating MongoDB, collections are dropped, therefore all indexes are lost.
This pull request propose using remove() method instead of drop(), which will remove all documents whilst preserving indexes.

### Additional info
Documentation on remove() method:

> To delete all documents in a collection, pass an empty document ({}).

Source: https://docs.mongodb.com/manual/reference/method/db.collection.remove/
