### PR TITLE
Add support for pre-built docker image (update only app layer)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,6 @@ jobs:
 
       - name: Docker build
         run: |
-          docker pull xhgui/xhgui:latest
-          docker build --cache-from=xhgui/xhgui:latest .
+          docker build --build-arg=BUILD_SOURCE=prebuilt .
 
 # vim:ft=yaml:et:ts=2:sw=2

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,13 +119,14 @@ WORKDIR $APPDIR
 EXPOSE 80
 CMD ["sh", "-c", "nginx && exec php-fpm"]
 VOLUME "/run/nginx"
-COPY --from=build --chown=www-data /cache ./cache/
 
 # runtime image from last release
 FROM xhgui/xhgui:latest AS runtime-prebuilt
+RUN rm -rf $(pwd)
 
 # build final image
 FROM runtime-$BUILD_SOURCE AS runtime
 
+COPY --from=build --chown=www-data /cache ./cache/
 COPY --from=build /vendor ./vendor/
 COPY --from=build /app ./


### PR DESCRIPTION
Problem is that --cache-from has no effect in GitHub Actions builds. The builds are always full, compiling pecl/mongodb from source:

Example:
- 1m 39s: https://github.com/perftools/xhgui/runs/1610535620

Let's save (some) green energy and don't build the extension from the source on each pull request.
This results in a bit bigger image, as the source is added twice to layers, but the image is still accurate.

Example:
- 17s: https://github.com/perftools/xhgui/runs/1610589204
