### PR TITLE
Tests: Destructurize $expectedIndex into [$keys, $options]

### DIFF
--- a/tests/Searcher/MongoHelper.php
+++ b/tests/Searcher/MongoHelper.php
@@ -2,9 +2,7 @@
 
 namespace XHGui\Test\Searcher;
 
-use ArrayIterator;
 use MongoDB;
-use MultipleIterator;
 
 class MongoHelper
 {
@@ -34,20 +32,18 @@ class MongoHelper
         $this->indexes[$collectionName] = $indexes;
     }
 
-    public function getIndexes(string $collectionName): MultipleIterator
+    public function getIndexes(string $collectionName): iterable
     {
         $collection = $this->mongodb->selectCollection($collectionName);
         $expectedIndexes = $this->indexes[$collectionName];
 
-        $resultIndexInfo = $collection->getIndexInfo();
-        $resultIndexes = array_column($resultIndexInfo, 'key');
-        $resultIndexNames = array_column($resultIndexInfo, 'name');
-
-        $iterator = new MultipleIterator();
-        $iterator->attachIterator(new ArrayIterator($resultIndexes));
-        $iterator->attachIterator(new ArrayIterator($resultIndexNames));
-        $iterator->attachIterator(new ArrayIterator($expectedIndexes));
-
-        return $iterator;
+        foreach ($collection->getIndexInfo() as $offset => $index) {
+            yield [
+                $index['key'],
+                $index['name'],
+                $expectedIndexes[$offset][0],
+                $expectedIndexes[$offset][1],
+            ];
+        }
     }
 }

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -2,7 +2,6 @@
 
 namespace XHGui\Test\Searcher;
 
-use MongoDB;
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
 use XHGui\Test\LazyContainerProperties;
@@ -18,7 +17,7 @@ class MongoTest extends TestCase
         $this->setupProperties();
 
         $this->skipIfPdo('This is MongoDB test');
-        $this->di[MongoDB::class]->watches->drop();
+        $this->mongodb->watches->drop();
         $this->importFixture($this->di['saver.mongodb']);
     }
 

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -217,13 +217,9 @@ class MongoTest extends TestCase
 
         // assert that all indexes are intact after truncating
         // compare result against expected indexes
-        foreach ($helper->getIndexes('results') as [$index, $name, $expectedIndex]) {
-            [$keys, $options] = $expectedIndex;
-
+        foreach ($helper->getIndexes('results') as [$index, $name, $keys, $options]) {
             $this->assertEquals($keys, $index);
-
-            $expectedName = $options['name'];
-            $this->assertEquals($expectedName, $name);
+            $this->assertEquals($options['name'], $name);
 
             if ($name === 'meta.request_ts') {
                 $this->assertArrayHasKey('expireAfterSeconds', $options);
@@ -258,11 +254,9 @@ class MongoTest extends TestCase
         $this->assertEmpty($result);
 
         // compare result against expected indexes
-        foreach ($helper->getIndexes('watches') as [$index, $name, $expectedIndex]) {
-            [$keys, $options] = $expectedIndex;
+        foreach ($helper->getIndexes('watches') as [$index, $name, $keys, $options]) {
             $this->assertEquals($keys, $index);
-            $expectedName = $options['name'];
-            $this->assertEquals($expectedName, $name);
+            $this->assertEquals($options['name'], $name);
         }
     }
 }

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -218,14 +218,16 @@ class MongoTest extends TestCase
         // assert that all indexes are intact after truncating
         // compare result against expected indexes
         foreach ($helper->getIndexes('results') as [$index, $name, $expectedIndex]) {
-            $this->assertEquals($expectedIndex[0], $index);
+            [$keys, $options] = $expectedIndex;
 
-            $expectedName = $expectedIndex[1]['name'];
+            $this->assertEquals($keys, $index);
+
+            $expectedName = $options['name'];
             $this->assertEquals($expectedName, $name);
 
             if ($name === 'meta.request_ts') {
-                $this->assertArrayHasKey('expireAfterSeconds', $expectedIndex[1]);
-                $this->assertEquals(432000, $expectedIndex[1]['expireAfterSeconds']);
+                $this->assertArrayHasKey('expireAfterSeconds', $options);
+                $this->assertEquals(432000, $options['expireAfterSeconds']);
             }
         }
     }
@@ -257,8 +259,9 @@ class MongoTest extends TestCase
 
         // compare result against expected indexes
         foreach ($helper->getIndexes('watches') as [$index, $name, $expectedIndex]) {
-            $this->assertEquals($expectedIndex[0], $index);
-            $expectedName = $expectedIndex[1]['name'];
+            [$keys, $options] = $expectedIndex;
+            $this->assertEquals($keys, $index);
+            $expectedName = $options['name'];
             $this->assertEquals($expectedName, $name);
         }
     }


### PR DESCRIPTION
Follow up to https://github.com/perftools/xhgui/pull/406

The code is more readable with variable names rather numeric offsets. This approach probably even uses less memory as well.

cc @codespill