### PR TITLE
Tests: Move LazyContainerProperties to base TestCase

### DIFF
--- a/tests/Controller/ImportTest.php
+++ b/tests/Controller/ImportTest.php
@@ -4,17 +4,13 @@ namespace XHGui\Test\Controller;
 
 use Slim\Environment;
 use XHGui\Profile;
-use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class ImportTest extends TestCase
 {
-    use LazyContainerProperties;
-
     public function setUp(): void
     {
         parent::setUp();
-        $this->setupProperties();
 
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',

--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -4,17 +4,13 @@ namespace XHGui\Test\Controller;
 
 use Slim\Environment;
 use XHGui\Options\SearchOptions;
-use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class RunTest extends TestCase
 {
-    use LazyContainerProperties;
-
     public function setUp(): void
     {
         parent::setUp();
-        $this->setupProperties();
 
         Environment::mock([
             'SCRIPT_NAME' => 'index.php',

--- a/tests/Controller/WatchTest.php
+++ b/tests/Controller/WatchTest.php
@@ -3,18 +3,14 @@
 namespace XHGui\Test\Controller;
 
 use Slim\Environment;
-use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class WatchTest extends TestCase
 {
-    use LazyContainerProperties;
-
     public function setUp(): void
     {
         $this->skipIfPdo('Watchers not implemented');
         parent::setUp();
-        $this->setupProperties();
 
         Environment::mock([
            'SCRIPT_NAME' => 'index.php',

--- a/tests/LazyContainerProperties.php
+++ b/tests/LazyContainerProperties.php
@@ -9,7 +9,7 @@ use Slim\View;
 use XHGui\Controller\ImportController;
 use XHGui\Controller\RunController;
 use XHGui\Controller\WatchController;
-use XHGui\Saver\MongoSaver;
+use XHGui\Saver\SaverInterface;
 use XHGui\Searcher\MongoSearcher;
 use XHGui\Searcher\SearcherInterface;
 use XHGui\ServiceContainer;
@@ -24,7 +24,7 @@ trait LazyContainerProperties
     /** @var ImportController */
     protected $import;
     /** @var MongoSearcher */
-    private $mongo;
+    protected $mongo;
     /** @var MongoDB */
     protected $mongodb;
     /** @var RunController */
@@ -33,7 +33,7 @@ trait LazyContainerProperties
     protected $app;
     /** @var SearcherInterface */
     protected $searcher;
-    /** @var MongoSaver */
+    /** @var SaverInterface */
     protected $saver;
     /** @var View */
     protected $view;

--- a/tests/MongoHelper.php
+++ b/tests/MongoHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace XHGui\Test\Searcher;
+namespace XHGui\Test;
 
 use MongoDB;
 

--- a/tests/Profile/ProfileTest.php
+++ b/tests/Profile/ProfileTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace XHGui\Test;
+namespace XHGui\Test\Profile;
 
 use DateTime;
 use XHGui\Profile;
+use XHGui\Test\TestCase;
 
 class ProfileTest extends TestCase
 {

--- a/tests/ProfileTest.php
+++ b/tests/ProfileTest.php
@@ -12,8 +12,7 @@ class ProfileTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $contents = file_get_contents(dirname(__DIR__) . '/tests/fixtures/results.json');
-        $this->fixture = json_decode($contents, true);
+        $this->fixture = $this->loadFixture('results.json');
     }
 
     public function testProcessIncompleteData(): void

--- a/tests/Saver/NormalizerTest.php
+++ b/tests/Saver/NormalizerTest.php
@@ -10,8 +10,6 @@ class NormalizerTest extends TestCase
 {
     /** @var NormalizingSaver */
     private $normalizer;
-    /** @var SaverInterface */
-    private $saver;
 
     public function setUp(): void
     {

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -4,6 +4,7 @@ namespace XHGui\Test\Searcher;
 
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
+use XHGui\Test\MongoHelper;
 use XHGui\Test\TestCase;
 
 class MongoTest extends TestCase

--- a/tests/Searcher/MongoTest.php
+++ b/tests/Searcher/MongoTest.php
@@ -4,19 +4,14 @@ namespace XHGui\Test\Searcher;
 
 use XHGui\Options\SearchOptions;
 use XHGui\Profile;
-use XHGui\Test\LazyContainerProperties;
 use XHGui\Test\TestCase;
 
 class MongoTest extends TestCase
 {
-    use LazyContainerProperties;
-
     public function setUp(): void
     {
-        parent::setUp();
-        $this->setupProperties();
-
         $this->skipIfPdo('This is MongoDB test');
+        parent::setUp();
         $this->mongodb->watches->drop();
         $this->importFixture($this->di['saver.mongodb']);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,14 @@ use XHGui\ServiceContainer;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
+    use LazyContainerProperties;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->setupProperties();
+    }
+
     /**
      * Load a fixture into the database.
      */


### PR DESCRIPTION
Move LazyContainerProperties to base TestCase.

This simplifies individual tests setup
