### PR TITLE
[0.19]: Tests: Port slim.request.form_hash to _POST

### DIFF
--- a/tests/Controller/RunTest.php
+++ b/tests/Controller/RunTest.php
@@ -171,12 +171,14 @@ class RunTest extends TestCase
 
         Environment::mock([
             'REQUEST_METHOD' => 'POST',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
             'SCRIPT_NAME' => 'index.php',
             'PATH_INFO' => '/run/delete',
-            'slim.request.form_hash' => [
-                'id' => 'aaaaaaaaaaaaaaaaaaaaaaaa',
-            ],
         ]);
+
+        $_POST = [
+            'id' => 'aaaaaaaaaaaaaaaaaaaaaaaa',
+        ];
 
         $this->app->expects($this->once())
             ->method('urlFor')


### PR DESCRIPTION
1. Don't use slim internal details
2. Be compatible with Slim 2.x
3. Be compatible with Slim 3.x