### PR TITLE
[0.18.2]: Tests: Skip MongoTest for pdo saver

### DIFF
--- a/tests/Saver/MongoTest.php
+++ b/tests/Saver/MongoTest.php
@@ -10,6 +10,8 @@ class MongoTest extends TestCase
 {
     public function testSave(): void
     {
+        $this->skipIfPdo('This is MongoDB test');
+
         $data = $this->loadFixture('normalized.json');
 
         $collection = $this->getMockBuilder(MongoCollection::class)


### PR DESCRIPTION
Skip MongoTest on non-mongo tests.

This worked before as probably setup-php included mongo extension unconditionally.