### PR TITLE
Docker: Use same alpine base image for all steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@
 # build (build from source), prebuilt (use copy from last release image)
 ARG BUILD_SOURCE=build
 
-FROM alpine:3.12 AS base
+FROM alpine:3.12 AS alpine
+
+FROM alpine AS base
 ENV PHP_INI_DIR /etc/php7
 
 # ext-mongodb: build and stage


### PR DESCRIPTION
This avoids roundtrips fetching multiple base images:
- https://github.com/perftools/xhgui/runs/2355381675