### PR TITLE
Use ORGANIZATION_ADMIN_TOKEN to trigger further workflows

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           command-name: "laminas:automatic-releases:release"
         env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
+          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
Try to fix that automatic releases did not trigger docker build:
- https://github.com/perftools/xhgui/pull/428#issuecomment-948327900