### PR TITLE
Updating PHP Versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ it.
 
 XHGui has the following requirements:
 
-- PHP version 7.2 up to 7.3
+- PHP version ^7.2 || ^8.0
 - If using MongoDB storage, see [MongoDB](#MongoDB) requirements
 - If using PDO storage, see [PDO](#PDO) requirements
 - To profile an application, one of the profiling PHP extensions is required.


### PR DESCRIPTION
Thanks for your work on this!

Fixes the PHP versions in `composer.json` not matching the readme.