### PR TITLE
Move Cache-Control header setup to routes

### DIFF
--- a/src/Controller/RunController.php
+++ b/src/Controller/RunController.php
@@ -30,12 +30,6 @@ class RunController extends AbstractController
 
     public function index(Request $request, Response $response): void
     {
-        // The list changes whenever new profiles are recorded.
-        // Generally avoid caching, but allow re-use in browser's bfcache
-        // and by cache proxies for concurrent requests.
-        // https://github.com/perftools/xhgui/issues/261
-        $response->headers->set('Cache-Control', 'public, max-age=0');
-
         $search = [];
         $keys = ['date_start', 'date_end', 'server_name', 'url'];
         foreach ($keys as $key) {
@@ -83,15 +77,6 @@ class RunController extends AbstractController
 
     public function view(Request $request, Response $response): void
     {
-        // Permalink views to a specific run are meant to be public and immutable.
-        // But limit the cache to only a short period of time (enough to allow
-        // handling of abuse or other stampedes). This way we don't have to
-        // deal with any kind of purging system for when profiles are deleted,
-        // or for after XHGui itself is upgraded and static assets may be
-        // incompatible etc.
-        // https://github.com/perftools/xhgui/issues/261
-        $response->headers->set('Cache-Control', 'public, max-age=60, must-revalidate');
-
         $detailCount = $this->config('detail.count');
         $result = $this->searcher->get($request->get('id'));
 


### PR DESCRIPTION
_Extracted from https://github.com/perftools/xhgui/pull/333_

In Slim v3:
This is due to the immutable response object, headers need to be set before calling the controller.