### PR TITLE
[slim3] Run xhgui in subdir

### DIFF
--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -12,7 +12,7 @@ class TwigExtension extends AbstractExtension
 {
     /** @var Router */
     private $router;
-    /** @var string|null */
+    /** @var string */
     private $pathPrefix;
     /** @var Request */
     private $request;
@@ -21,6 +21,9 @@ class TwigExtension extends AbstractExtension
     {
         $this->router = $router;
         $this->request = $request;
+        if (!$pathPrefix) {
+            $pathPrefix = '';
+        }
         $this->pathPrefix = $pathPrefix;
     }
 
@@ -75,15 +78,10 @@ class TwigExtension extends AbstractExtension
             $query = '?' . http_build_query($queryargs);
         }
 
-        $prepend = '';
-        if ($this->pathPrefix !== null) {
-            $prepend = rtrim($this->pathPrefix, '/');
-        }
-
         // this is copy of \Slim\Slim::urlFor()
         // to mix path prefix in \Slim\Slim::urlFor
 
-        return $prepend . $this->router->urlFor($name) . $query;
+        return rtrim($this->pathPrefix, '/') . $this->router->urlFor($name) . $query;
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -135,7 +135,7 @@ class TwigExtension extends AbstractExtension
 
     private function pathPrefix(): string
     {
-        if ($this->pathPrefix !== null) {
+        if ($this->pathPrefix !== '') {
             return $this->pathPrefix;
         }
 

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -12,7 +12,7 @@ class TwigExtension extends AbstractExtension
 {
     /** @var Router */
     private $router;
-    /** @var string */
+    /** @var string|null */
     private $pathPrefix;
     /** @var Request */
     private $request;

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -75,10 +75,15 @@ class TwigExtension extends AbstractExtension
             $query = '?' . http_build_query($queryargs);
         }
 
+        $prepend = '';
+        if ($this->pathPrefix !== null) {
+            $prepend = rtrim($this->pathPrefix, '/');
+        }
+
         // this is copy of \Slim\Slim::urlFor()
         // to mix path prefix in \Slim\Slim::urlFor
 
-        return rtrim($this->pathPrefix(), '/') . $this->router->urlFor($name) . $query;
+        return $prepend . $this->router->urlFor($name) . $query;
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -21,9 +21,6 @@ class TwigExtension extends AbstractExtension
     {
         $this->router = $router;
         $this->request = $request;
-        if (!$pathPrefix) {
-            $pathPrefix = '';
-        }
         $this->pathPrefix = $pathPrefix;
     }
 
@@ -81,7 +78,9 @@ class TwigExtension extends AbstractExtension
         // this is copy of \Slim\Slim::urlFor()
         // to mix path prefix in \Slim\Slim::urlFor
 
-        return rtrim($this->pathPrefix, '/') . $this->router->urlFor($name) . $query;
+        $prepend = $this->pathPrefix ?: '';
+
+        return rtrim($prepend, '/') . $this->router->urlFor($name) . $query;
     }
 
     /**
@@ -135,7 +134,7 @@ class TwigExtension extends AbstractExtension
 
     private function pathPrefix(): string
     {
-        if ($this->pathPrefix !== '') {
+        if ($this->pathPrefix !== null) {
             return $this->pathPrefix;
         }
 


### PR DESCRIPTION
A little change to be able to run xhgui with slim3 in a subdir.

I need to run xhgui  on https://localhost/xhgui/.
The gui loads in general. Links work, but css and js are not found because the links are going to `/` instead of `/xhgui`