### PR TITLE
Fix: Flash messages after Slim upgrade to 3.x

### DIFF
--- a/src/AbstractController.php
+++ b/src/AbstractController.php
@@ -28,6 +28,13 @@ abstract class AbstractController
         /** @var Twig $renderer */
         $renderer = $container->get('view');
 
+        if (!isset($data['flash'])) {
+            /** @var Flash\Messages $flash */
+            $flash = $this->app->getContainer()->get('flash');
+            $messages = $flash->getMessages();
+            $data['flash'] = $messages;
+        }
+
         $renderer->render($response, $template, $data);
     }
 

--- a/templates/layout/base.twig
+++ b/templates/layout/base.twig
@@ -36,7 +36,9 @@
     <div class="container-fluid">
         {% if flash.success %}
         <div class="flash alert alert-success">
-            {{ flash.success }}
+            {% for msg in flash.success %}
+                <li>{{ msg }}</li>
+            {% endfor %}
         </div>
         {% endif %}
 

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -4,5 +4,7 @@ use XHGui\Application;
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
+session_start();
+
 $app = new Application();
 $app->run();


### PR DESCRIPTION
Flash message work if there is a session_start.....

They could run with an array as storage, but I didn't get it working.

Also I added the assignment to `AbstractController::render`