### PR TITLE
Fix TwigExtension: Strip basePath from urlFor result

### DIFF
--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -78,11 +78,11 @@ class TwigExtension extends AbstractExtension
         $url = $this->router->urlFor($name);
 
         // Remove basePath from url
-        if (strpos($url, $this->basePath) === 0) {
-            $url = ltrim(substr($url, strlen($this->basePath)), '/');
+        if ($this->basePath && strpos($url, $this->basePath) === 0) {
+            $url = substr($url, strlen($this->basePath));
         }
 
-        return $this->pathPrefix($url . $query);
+        return $this->pathPrefix(ltrim($url, '/') . $query);
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -21,7 +21,7 @@ class TwigExtension extends AbstractExtension
     {
         $this->router = $router;
         $this->basePath = $request->getUri()->getBasePath();
-        $this->pathPrefix = $this->buildPathPrefix($this->basePath, $pathPrefix);
+        $this->pathPrefix = rtrim($this->buildPathPrefix($this->basePath, $pathPrefix), '/');
     }
 
     public function getFunctions(): array
@@ -134,13 +134,13 @@ class TwigExtension extends AbstractExtension
 
     private function pathPrefix($path): string
     {
-        return rtrim($this->pathPrefix, '/') . '/'. $path;
+        return $this->pathPrefix . '/' . $path;
     }
 
     private function buildPathPrefix(string $rootUri, ?string $pathPrefix): string
     {
         if ($pathPrefix !== null) {
-            return $pathPrefix;
+            return rtrim($pathPrefix, '/');
         }
 
         // Get URL part prepending index.php
@@ -149,6 +149,6 @@ class TwigExtension extends AbstractExtension
             return substr($rootUri, 0, $indexPos);
         }
 
-        return $rootUri;
+        return rtrim($rootUri, '/');
     }
 }

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -75,7 +75,15 @@ class TwigExtension extends AbstractExtension
             $query = '?' . http_build_query($queryargs);
         }
 
-        return $this->pathPrefix($this->router->urlFor($name) . $query);
+        $basePath = $this->getBasePath();
+        $url = $this->router->urlFor($name);
+
+        // Remove basePath from url
+        if (strpos($url, $basePath) === 0) {
+            $url = ltrim(substr($url, strlen($basePath)), '/');
+        }
+
+        return $this->pathPrefix($url . $query);
     }
 
     /**

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -78,7 +78,7 @@ class TwigExtension extends AbstractExtension
         // this is copy of \Slim\Slim::urlFor()
         // to mix path prefix in \Slim\Slim::urlFor
 
-        return rtrim($this->pathPrefix(), '/') . $this->router->urlFor($name) . $query;
+        return rtrim($this->getPathPrefix(), '/') . $this->router->urlFor($name) . $query;
     }
 
     /**
@@ -89,7 +89,7 @@ class TwigExtension extends AbstractExtension
      */
     public function staticUrl(string $path): string
     {
-        $rootUri = $this->pathPrefix();
+        $rootUri = $this->getPathPrefix();
 
         return rtrim($rootUri, '/') . '/' . $path;
     }
@@ -130,7 +130,7 @@ class TwigExtension extends AbstractExtension
         return number_format((float)$value * 100, 0) . ' <span class="units">%</span>';
     }
 
-    private function pathPrefix(): string
+    private function getPathPrefix(): string
     {
         if ($this->pathPrefix !== null) {
             return $this->pathPrefix;

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -75,10 +75,7 @@ class TwigExtension extends AbstractExtension
             $query = '?' . http_build_query($queryargs);
         }
 
-        // this is copy of \Slim\Slim::urlFor()
-        // to mix path prefix in \Slim\Slim::urlFor
-
-        return rtrim($this->getPathPrefix(), '/') . $this->router->urlFor($name) . $query;
+        return $this->pathPrefix($this->router->urlFor($name) . $query);
     }
 
     /**
@@ -89,9 +86,7 @@ class TwigExtension extends AbstractExtension
      */
     public function staticUrl(string $path): string
     {
-        $rootUri = $this->getPathPrefix();
-
-        return rtrim($rootUri, '/') . '/' . $path;
+        return $this->pathPrefix($path);
     }
 
     public function formatBytes($value): string
@@ -128,6 +123,11 @@ class TwigExtension extends AbstractExtension
     public function formatPercent($value): string
     {
         return number_format((float)$value * 100, 0) . ' <span class="units">%</span>';
+    }
+
+    private function pathPrefix($path): string
+    {
+        return rtrim($this->getPathPrefix(), '/') . '/'. $path;
     }
 
     private function getPathPrefix(): string

--- a/src/Twig/TwigExtension.php
+++ b/src/Twig/TwigExtension.php
@@ -136,7 +136,7 @@ class TwigExtension extends AbstractExtension
             return $this->pathPrefix;
         }
 
-        $rootUri = $this->request->getUri()->getBasePath();
+        $rootUri = $this->getBasePath();
 
         // Get URL part prepending index.php
         $indexPos = strpos($rootUri, 'index.php');
@@ -145,5 +145,10 @@ class TwigExtension extends AbstractExtension
         }
 
         return $rootUri;
+    }
+
+    private function getBasePath(): string
+    {
+        return $this->request->getUri()->getBasePath();
     }
 }


### PR DESCRIPTION
Replaces https://github.com/perftools/xhgui/pull/450

This avoids double base path for URLs when application is deployed to subdir.