### PR TITLE
Docs: Promote perftools/php-profiler more earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,16 @@
 
 A graphical interface for XHProf profiling data that can store the results in MongoDB or PDO database.
 
-Application is [profiled](#profiling-a-web-request-or-cli-script) and the
+Application is profiled and the
 profiling data is transferred to XHGui, which takes that information, saves it
 in MongoDB (or PDO database), and provides a convenient GUI for working with
 it.
+
+This project is the GUI for showing profiling results,
+to profile your application, use specific minimal library:
+- [perftools/php-profiler]
+
+[perftools/php-profiler]: #profiling-a-web-request-or-cli-script
 
 [![Build Status](https://travis-ci.org/perftools/xhgui.svg?branch=master)](https://travis-ci.org/perftools/xhgui)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/perftools/xhgui/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/perftools/xhgui/?branch=master)


### PR DESCRIPTION
As seems, people still want to install GUI aside from their application
while there's is no such need to pull so many dependencies to their
application.

Perhaps the problem is that the documentation is not clear enough and the projects used to be the same repository, but this is not the case for very long already.

refs:
- https://github.com/perftools/xhgui/issues/434#issuecomment-957172239
- https://github.com/perftools/xhgui/issues/434#issuecomment-1014746299
- https://github.com/perftools/xhgui/issues/278#issuecomment-1011439472