### PR TITLE
Publish Docker image when a new release is published on GitHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,19 +6,10 @@
 name: Publish Docker image
 
 on:
-  # Runs your workflow when someone creates a Git reference (Git branch or tag) in the workflow's repository.
-  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#create
-  # Note: An event will not be created when you create more than three tags at once.
-  create:
-    tags:
-      - "*.*.*"
-
-  # Runs your workflow when you push a commit or tag.
-  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#push
-  # Note: An event will not be created when you push more than three tags at once.
-  push:
-    branches:
-      - "*.*.x"
+  # Runs your workflow when a release or draft of a release is published on GitHub.
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
+  release:
+    types: [published]
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,12 @@
 name: Publish Docker image
 
 on:
+  # Runs your workflow when you push a commit or tag.
+  # https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#push
+  # Note: An event will not be created when you push more than three tags at once.
+  push:
+    branches:
+      - "*.*.x"
   # Runs your workflow when a release or draft of a release is published on GitHub.
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release
   release:


### PR DESCRIPTION
This patch resolves #427, via the following changes:

 - Update `.github/workflows/docker.yml`

Docs: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images