### PR TITLE
Correct argument $request for WaterfallController::query() in RouteProvider.

### DIFF
--- a/src/ServiceProvider/RouteProvider.php
+++ b/src/ServiceProvider/RouteProvider.php
@@ -202,7 +202,7 @@ class RouteProvider implements ServiceProviderInterface
             /** @var Controller\WaterfallController $controller */
             $controller = $di[Controller\WaterfallController::class];
 
-            $data = $controller->query($di['response.proxy']);
+            $data = $controller->query($request);
 
             $response
                 ->setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
Fix for:

```
xhgui_1        | 2022/03/01 16:28:08 [error] 36#36: *3 FastCGI sent in stderr: "PHP message: Slim Application Error:
xhgui_1        | Type: Pimple\Exception\UnknownIdentifierException
xhgui_1        | Message: Identifier &quot;response.proxy&quot; is not defined.
xhgui_1        | File: /var/www/xhgui/vendor/pimple/pimple/src/Pimple/Container.php
xhgui_1        | Line: 105
xhgui_1        | Trace: #0 /var/www/xhgui/src/ServiceProvider/RouteProvider.php(205): Pimple\Container->offsetGet()
xhgui_1        | #1 /var/www/xhgui/src/ServiceProvider/RouteProvider.php(31): XHGui\ServiceProvider\RouteProvider->XHGui\ServiceProvider\{closure}()
xhgui_1        | #2 [internal function]: XHGui\ServiceProvider\RouteProvider->XHGui\ServiceProvider\{closure}()
xhgui_1        | #3 /var/www/xhgui/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(40): call_user_func()
xhgui_1        | #4 /var/www/xhgui/vendor/slim/slim/Slim/Route.php(281): Slim\Handlers\Strategies\RequestResponse->__invoke()
xhgui_1        | #5 /var/www/xhgui/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\Route->__invoke()
xhgui_1        | #6 /var/www/xhgui/vendor/slim/slim/Slim/Route.php(268): Slim\Route->callMiddlewareStack()
xhgui_1        | #7 /var/www/xhgui/vendor/slim/slim/Slim/App.php(503): Slim\Route" while reading response header from upstream, client: 172.18.0.1, server: , request: "GET /waterfall/data?remote_addr=172.18.0.1&request_start=1646148934&request_end=16461489
```

See https://github.com/perftools/xhgui/commit/ea83f10f501464651bbdfdb9c626c86628ae71eb#r67785008