### PR TITLE
Update PdoRepository::initSchema() to create table with profile as LONGTEXT.

### DIFF
--- a/src/Db/PdoRepository.php
+++ b/src/Db/PdoRepository.php
@@ -187,7 +187,7 @@ class PdoRepository
         $this->pdo->exec(sprintf('
             CREATE TABLE IF NOT EXISTS %s (
               "id"               CHAR(24) PRIMARY KEY,
-              "profile"          TEXT           NOT NULL,
+              "profile"          LONGTEXT       NOT NULL,
               "url"              TEXT           NULL,
               "SERVER"           TEXT           NULL,
               "GET"              TEXT           NULL,


### PR DESCRIPTION
In larger applications profile column of type `TEXT` exceeds maximum allowed characters of 65535 characters. This leads to data not showing in UI since `json_decode()` returns `null` on truncated JSON string.

Replaces https://github.com/perftools/xhgui/pull/437