### PR TITLE
Increase `client_max_body_size` to 5 MB

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -7,6 +7,8 @@ server {
     root   /var/www/xhgui/webroot;
     index  index.php;
 
+    client_max_body_size 5M;
+
     location / {
         try_files $uri $uri/ /index.php$is_args$args;
     }


### PR DESCRIPTION
The default `client_max_body_size` is 1MB and may be too low for more complex data submissions. IMHO, increasing it to 5M should not do too much harm resource-wise.

Since the PHP Profiler silently discards errors when uploading data ([here](https://github.com/perftools/php-profiler/blob/67c7ebf6404f10a6ad7821ac2faccb840b784e4a/src/Profiler.php#L230)), it is not obvious for newcomers to understand why data does not show up. Thus, I think avoiding background errors like 413 is important.