### PR TITLE
Fix missing required parameter in RunController:274

### DIFF
--- a/src/Controller/RunController.php
+++ b/src/Controller/RunController.php
@@ -273,7 +273,7 @@ class RunController extends AbstractController
             'candidates' => $candidates,
             'url_params' => $request->getQueryParams(),
             'comparison' => $comparison,
-            'pagination' => $paging,
+            'paging' => $paging,
             'search' => [
                 'base' => $request->get('base'),
                 'head' => $request->get('head'),

--- a/src/Controller/RunController.php
+++ b/src/Controller/RunController.php
@@ -271,10 +271,8 @@ class RunController extends AbstractController
             'base_run' => $baseRun,
             'head_run' => $headRun,
             'candidates' => $candidates,
-            // 'url_params' => $request->get(),
             'url_params' => $request->getQueryParams(),
             'comparison' => $comparison,
-            'paging' => $paging,
             'pagination' => $paging,
             'search' => [
                 'base' => $request->get('base'),

--- a/src/Controller/RunController.php
+++ b/src/Controller/RunController.php
@@ -271,9 +271,11 @@ class RunController extends AbstractController
             'base_run' => $baseRun,
             'head_run' => $headRun,
             'candidates' => $candidates,
-            'url_params' => $request->get(),
+            // 'url_params' => $request->get(),
+            'url_params' => $request->getQueryParams(),
             'comparison' => $comparison,
             'paging' => $paging,
+            'pagination' => $paging,
             'search' => [
                 'base' => $request->get('base'),
                 'head' => $request->get('head'),

--- a/src/RequestProxy.php
+++ b/src/RequestProxy.php
@@ -17,6 +17,11 @@ class RequestProxy
         $this->request = $request;
     }
 
+    public function getQueryParams()
+    {
+        return $this->request->getQueryParams();
+    }
+
     public function get(string $key, $default = null)
     {
         return $this->request->getQueryParam($key, $default);

--- a/templates/runs/compare.twig
+++ b/templates/runs/compare.twig
@@ -36,7 +36,7 @@
     <div class="row-fluid row-spaced">
         <h3>Other runs with {{ base_run.meta.simple_url }}</h3>
         {% include 'runs/paginated-list.twig' with {runs: candidates.results, show_compare_link: true} %}
-        {{ helpers.pagination('run.compare', pagination, url_params) }}
+        {{ helpers.pagination('run.compare', paging, url_params) }}
     </div>
     {% endif %}
 


### PR DESCRIPTION
when I access `/run/compare?base=xxx` page, Pagination is unavailable because of this bug.
because `templates/runs/compare.twig`  referencing a nonexistent value -> `{{ helpers.pagination('run.compare', pagination, url_params) }}`

fixes https://github.com/perftools/xhgui/issues/471