### PR TITLE
Put the nginx conf to the correct place

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: always
     volumes:
       - ./config:/var/www/xhgui/config
-      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx.conf:/etc/nginx/http.d/default.conf:ro
     environment:
       - XHGUI_MONGO_HOSTNAME=mongo
       - XHGUI_MONGO_DATABASE=xhprof


### PR DESCRIPTION
When using Docker installation method, Nginx reads the http.d instead of conf.d.