### PR TITLE
Replace sql type TEXT by LONGTEXT for profile field when using mysql …

### DIFF
--- a/src/Db/PdoRepository.php
+++ b/src/Db/PdoRepository.php
@@ -184,10 +184,11 @@ class PdoRepository
 
     public function initSchema(): void
     {
+        $profileColumnType = $this->driverName === 'mysql' ? 'LONGTEXT' : 'TEXT';
         $this->pdo->exec(sprintf('
             CREATE TABLE IF NOT EXISTS %s (
               "id"               CHAR(24) PRIMARY KEY,
-              "profile"          TEXT           NOT NULL,
+              "profile"          %s             NOT NULL,
               "url"              TEXT           NULL,
               "SERVER"           TEXT           NULL,
               "GET"              TEXT           NULL,
@@ -202,7 +203,7 @@ class PdoRepository
               "main_mu"          INTEGER        NOT NULL,
               "main_pmu"         INTEGER        NOT NULL
             )
-        ', $this->table));
+        ', $this->table, $profileColumnType));
         $this->pdo->exec(sprintf('
             CREATE TABLE IF NOT EXISTS %s (
               "id"               CHAR(24) PRIMARY KEY,


### PR DESCRIPTION
## Problem
mysql driver truncate data when using field type `TEXT` while exceeding 65535 characters

## Solution
Use field type `LONGTEXT` when using mysql driver.

## Related PR
- https://github.com/perftools/xhgui/pull/437
- https://github.com/perftools/xhgui/pull/474
- https://github.com/perftools/xhgui/pull/486

## Alternative

I believe it could add a nice touch to implement an abstract class as a Driver helper. 
Something like this:

```php
<?php

namespace XHGui\Db;

abstract class PdoDriverAbstract 
{
    /* @var PdoDriverAbstract */
    private $driver;

    public function __construct(string $driverName) 
    {
        switch($driverName)
        {
            case "mysql":
                $this->driver = new PdoMysqlDriver();
                break;
            default:
                $this->driver = new PdoSqliteDriver();
        }

    }
    
    abstract public function getTableQuery(): string;
}
```

Then we could do something like this:

```php
 public function __construct(PDO $pdo, string $driverName, string $table, string $tableWatch)
    {
        $this->pdo = $pdo;
        $this->driver = new PdoDriverAbstract($driverName);
        $this->table = sprintf('"%s"', $table);
        $this->tableWatches = sprintf('"%s"', $tableWatch);
        $this->initSchema();
    }

 public function initSchema(): void
    {
            $this->pdo->exec($this->driver->getTableQuery()
                ', $this->table));
   ...
}
```

It would be ready to scale if other exception happens in the futur...but then its a bit overkill for now.

Let me know !
