### PR TITLE
PDO: Move online schema creation behind feature flag

### DIFF
--- a/config/config.default.php
+++ b/config/config.default.php
@@ -18,6 +18,7 @@ return [
         'pass' => getenv('XHGUI_PDO_PASS') ?: null,
         'table' => getenv('XHGUI_PDO_TABLE') ?: 'results',
         'tableWatch' => getenv('XHGUI_PDO_TABLE_WATCHES') ?: 'watches',
+        'initSchema' => getenv('XHGUI_PDO_INITSCHEMA') ?: 'true',
     ],
 
     // Database options for MongoDB.

--- a/src/Db/PdoRepository.php
+++ b/src/Db/PdoRepository.php
@@ -34,7 +34,6 @@ class PdoRepository
         $this->driverName = $driverName;
         $this->table = sprintf('"%s"', $table);
         $this->tableWatches = sprintf('"%s"', $tableWatch);
-        $this->initSchema();
     }
 
     public function getLatest(): array

--- a/src/ServiceProvider/PdoStorageProvider.php
+++ b/src/ServiceProvider/PdoStorageProvider.php
@@ -48,12 +48,16 @@ class PdoStorageProvider implements ServiceProviderInterface
         };
 
         $app[PdoRepository::class] = static function ($app) {
-            return new PdoRepository(
+            $repo = new PdoRepository(
                 $app['pdo'],
                 $app['pdo.driver'],
                 $app['config']['pdo']['table'],
                 $app['config']['pdo']['tableWatch']
             );
+            if ($app['config']['pdo']['initSchema'] === 'true') {
+                $repo->initSchema();
+            }
+            return $repo;
         };
 
         $app['searcher.pdo'] = static function ($app) {


### PR DESCRIPTION
The XHGui install at Wikimedia Foundation is deployed with database credentials that permit read-write operations (SELECT, INSERT) but as safety precaution do not permit admin actions like CREATE from individual web requests. In addition to not allowing admin actions, our install also disallows DELETE queries, given that the install is exposed to the public Internet (ref https://github.com/perftools/xhgui/issues/248) and further disables POST requests (so that those features serve HTTP 40x instead of a db query error with HTTP 50x).

Since XHGui version 0.16.0, with https://github.com/perftools/xhgui/pull/355, the lazy-creation for tables was moved from the Saver code (which is not used when browsing XHGui) to to Repo code, and thus resulted in the application serving HTTP 500 on all requests, unless the `CREATE TABLE` query is permitted on all web requests.

Fix this by making this method call feature flagged in a way that can be disabled.

Downstream task: https://phabricator.wikimedia.org/T341499