### PR TITLE
Show the parent-child call count on the graph

### DIFF
--- a/src/Profile.php
+++ b/src/Profile.php
@@ -72,6 +72,11 @@ class Profile
             } else {
                 $result[$func] = $values;
                 $result[$func]['parents'] = [$parent];
+                $result[$func]['parents_calls'] = [];
+            }
+
+            if ($parent) {
+                $result[$func]['parents_calls'][$parent] = ($result[$func]['parents_calls'][$parent] ?? 0) + $values['ct'];
             }
 
             // Build the indexed data.
@@ -622,7 +627,7 @@ class Profile
                 $this->links[] = [
                     'source' => $parentName,
                     'target' => $childName,
-                    'callCount' => $metrics['ct'],
+                    'callCount' => $metrics['parents_calls'][$parentName] ?? $metrics['ct'],
                 ];
             }
 

--- a/tests/Profile/ProfileTest.php
+++ b/tests/Profile/ProfileTest.php
@@ -189,7 +189,7 @@ class ProfileTest extends TestCase
 
         $expected = $fixture['profile']['main()'];
         $result = $profile->get('main()');
-        unset($result['parents']);
+        unset($result['parents'], $result['parents_calls']);
         $this->assertEquals($expected, $result);
 
         $this->assertNull($profile->get('main()', 'derp'));
@@ -396,7 +396,7 @@ class ProfileTest extends TestCase
                 [
                     'source' => 'eat_burger()',
                     'target' => 'strlen()',
-                    'callCount' => 2,
+                    'callCount' => 1,
                 ],
                 [
                     'source' => 'main()',
@@ -411,11 +411,12 @@ class ProfileTest extends TestCase
                 [
                     'source' => 'drink_beer()',
                     'target' => 'strlen()',
-                    'callCount' => 2,
+                    'callCount' => 1,
                 ],
             ],
         ];
         $result = $profile->getCallgraph();
+
         $this->assertEquals($expected, $result);
     }
 
@@ -462,7 +463,7 @@ class ProfileTest extends TestCase
                 [
                     'source' => 'load_file()',
                     'target' => 'open()',
-                    'callCount' => 2,
+                    'callCount' => 1,
                 ],
                 [
                     'source' => 'open()',
@@ -477,7 +478,7 @@ class ProfileTest extends TestCase
                 [
                     'source' => 'parse_string()',
                     'target' => 'open()',
-                    'callCount' => 2,
+                    'callCount' => 1,
                 ],
             ],
         ];


### PR DESCRIPTION
Hey

I noticed when using the callgraph that the call counts on the edges appear to use the total number of calls to the child function across the graph, rather than the number of calls from the parent function to the child.

I've made a change to track those individually, and updated a test that I thought should be failing.
Please let me know if you'd prefer it done in a different way or would like any changes.

Before (note that they all say 59 calls - which is wrong):
![callgraph_before](https://github.com/user-attachments/assets/d4a63dfe-b0bf-42f6-9ec9-b8fb92f33367)
After:
![callgraph_after](https://github.com/user-attachments/assets/1fa877e6-d290-4217-87f3-9aafdb319228)

![image](https://github.com/user-attachments/assets/54c3757c-ea29-459a-8838-770c7180ecc9)


