### PR TITLE
Fix the static path for the loading.gif file

### DIFF
--- a/templates/custom/create.twig
+++ b/templates/custom/create.twig
@@ -43,7 +43,7 @@
 
     <div class="span12">
         <div class="btn btn-large" style="display: block; margin-left: auto; margin-right: auto; width: 150px;" id="runbutton">Run</div>
-		<div style="display: block; margin-left: auto; margin-right: auto; width: 150px; display: none" id="loading"><img src="{{ static('/img/loading.gif') }}"></div>
+		<div style="display: block; margin-left: auto; margin-right: auto; width: 150px; display: none" id="loading"><img src="{{ static('img/loading.gif') }}"></div>
     </div><!--/span-->
 
 


### PR DESCRIPTION
Fixes #506 
While testing out xhgui with ddev, I found out this issue about the path of the loading.gif in the custom view page.