### PR TITLE
Tests: Use mongo 4.0 server in CI for mongo tests

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       mongodb:
-        image: percona/percona-server-mongodb:3.6
+        image: percona/percona-server-mongodb:4.0
         ports:
           - 27017:27017
 


### PR DESCRIPTION
> MongoConnectionException: Server at 127.0.0.1:27017 reports wire version 6,
> but this version of libmongoc requires at least 7 (MongoDB 4.0)
- https://github.com/perftools/xhgui/actions/runs/14131456580/job/39592574358#step:8:22