### PR TITLE
Cleanup: Remove docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   xhgui:
     # https://hub.docker.com/r/xhgui/xhgui/tags


### PR DESCRIPTION
```
$ docker-compose up -d
WARN[0000] docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```