### PR TITLE
Fix: Update xip.io url with nip.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This setup uses [docker-compose] to orchestrate docker containers.
 
 2. Startup the containers: `docker-compose up -d`
 
-3. Open your browser at http://xhgui.127.0.0.1.xip.io:8142 or just http://localhost:8142 or type at terminal `composer open`
+3. Open your browser at http://xhgui.127.0.0.1.nip.io:8142 or just http://localhost:8142 or type at terminal `composer open`
 
 4. To customize xhgui, copy `config/config.default.php` to `config/config.php` and edit that file.
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
             "@phpunit-setup"
         ],
         "cover": "simple-phpunit --coverage-clover=unittest-coverage.clover",
-        "openurl": "open http://xhgui.127.0.0.1.xip.io:8142",
+        "openurl": "open http://xhgui.127.0.0.1.nip.io:8142",
         "phpunit-setup": "test $COMPOSER_DEV_MODE = 0 || simple-phpunit --version",
         "test": "simple-phpunit"
     }


### PR DESCRIPTION
xip.io is dead, long live xip.io!