### PR TITLE
Fix: Add iconv extension for twig 3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -x \
 		php8-simplexml \
 		php8-session \
 		php8-pecl-mongodb \
+        php8-iconv \
 	# Use www-data uid from alpine also present in docker php images
 	&& adduser -u 82 -D -S -G www-data www-data \
 	# Tweak php-fpm config


### PR DESCRIPTION
Target branch is [perftools:dependabot/composer/twig/twig-3.11.2](https://github.com/perftools/xhgui/tree/dependabot/composer/twig/twig-3.11.2) to fix an issue on PR #510 . 

Without the iconv extension, we get the error : 
```
Type: Twig\Error\RuntimeError
Message: An exception has been thrown during the rendering of a template (&quot;Call to undefined function Symfony\Polyfill\Mbstring\iconv_strlen()&quot;).
File: /var/www/xhgui/templates/runs/paginated-list.twig
```

This PR adds the php8-iconv extension.