### PR TITLE
Fix: Return an error if the query function is not supported.

### DIFF
--- a/src/Controller/CustomController.php
+++ b/src/Controller/CustomController.php
@@ -56,7 +56,6 @@ class CustomController extends AbstractController
         }
 
         $perPage = $this->config('page.limit');
-
         try {
             $results = $this->searcher->query($conditions, $perPage, $fields);
         } catch (NotImplementedException $e) {

--- a/src/Controller/CustomController.php
+++ b/src/Controller/CustomController.php
@@ -4,6 +4,7 @@ namespace XHGui\Controller;
 
 use Slim\App;
 use XHGui\AbstractController;
+use XHGui\Exception\NotImplementedException;
 use XHGui\RequestProxy as Request;
 use XHGui\Searcher\SearcherInterface;
 
@@ -56,6 +57,11 @@ class CustomController extends AbstractController
 
         $perPage = $this->config('page.limit');
 
-        return $this->searcher->query($conditions, $perPage, $fields);
+        try {
+            $results = $this->searcher->query($conditions, $perPage, $fields);
+        } catch (NotImplementedException $e) {
+            return ['error' => ['generic' => 'Not available for your save handler.']];
+        }
+        return $results;
     }
 }

--- a/src/Controller/CustomController.php
+++ b/src/Controller/CustomController.php
@@ -61,6 +61,7 @@ class CustomController extends AbstractController
         } catch (NotImplementedException $e) {
             return ['error' => ['generic' => 'Not available for your save handler.']];
         }
+
         return $results;
     }
 }

--- a/templates/custom/create.twig
+++ b/templates/custom/create.twig
@@ -39,19 +39,12 @@
     </div><!--/span-->
   
   </div><!--/row-->
-    <div class="row-fluid">
-
-    <div class="span12">
+ <div class="row-fluid">
+    <div class="span12" id="run-button-container">
         <div class="btn btn-large" style="display: block; margin-left: auto; margin-right: auto; width: 150px;" id="runbutton">Run</div>
 		<div style="display: block; margin-left: auto; margin-right: auto; width: 150px; display: none" id="loading"><img src="{{ static('img/loading.gif') }}"></div>
     </div><!--/span-->
 
-
-
-
-
-
-  
   </div><!--/row-->
   <table class="table table-hover" id="results">
     <thead>
@@ -105,7 +98,6 @@
                     $("#loading").hide();
                     if (data.hasOwnProperty('error'))
                     {
-                      console.log(data.error);
                       if (data.error.hasOwnProperty('query'))
                       {
                         $('#selection').animate(
@@ -126,6 +118,18 @@
                         $(this).animate({ backgroundColor: '#FFF'});
                         }
                         );
+                      }
+
+                      if (data.error.hasOwnProperty('generic'))
+                      {
+                          $('#run-button-container').animate(
+                              { backgroundColor: '#FFD9D9'},
+                              800,
+                              function() {
+                                  $(this).animate({ backgroundColor: '#FFF'});
+                              }
+                          );
+                          $('#run-button-container').text(data.error.generic);
                       }
                     }else  {
                       $.each( data, function(i, n){


### PR DESCRIPTION
The PdoSearcher does not support the query function. 

This PR adds a generic error "Not available for your save handler." and replace the Run button in the /custom page when 'pdo' is set as the save handler.

I think it would be a better UX to not show the menu link item, but I'm having issues getting access to the config from template level, or even from a twig function. If you have any tips...