### PR TITLE
Update composer php platform to 8.0.30, drop 7.2, 7.3 from CI tests

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -11,8 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "7.2"
-          - "7.3"
           - "7.4"
 
     services:

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
 

--- a/.github/workflows/tests-pgsql.yml
+++ b/.github/workflows/tests-pgsql.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
 

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -10,8 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
-          - "7.3"
           - "7.4"
           - "8.0"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.envrc.local
+/.phpunit.result.cache
 /composer.phar
 /tags
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "twig/twig": "^1.26"
     },
     "require-dev": {
-        "ocramius/lazy-property": "^1.0",
+        "ocramius/lazy-property": "^1.0 || ~2.1.0",
         "symfony/phpunit-bridge": "^7.2"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2.5",
+            "php": "7.4.33",
             "ext-mongodb": "1.3.0"
         },
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.4.33",
+            "php": "8.0.30",
             "ext-mongodb": "1.3.0"
         },
         "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c6863a73aaa06f3aa7165d8fa611d939",
+    "content-hash": "24f6d10fac8eaf041ea319ebcde4c101",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -914,7 +914,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.33",
+        "php": "8.0.30",
         "ext-mongodb": "1.3.0"
     },
     "plugin-api-version": "2.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a729f1d0c1020203e17b437a8c6fda6a",
+    "content-hash": "952d4d677226babe2fb5779d3b4a3b46",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -905,7 +905,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.5",
+        "php": "7.4.33",
         "ext-mongodb": "1.3.0"
     },
     "plugin-api-version": "2.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "952d4d677226babe2fb5779d3b4a3b46",
+    "content-hash": "c6863a73aaa06f3aa7165d8fa611d939",
     "packages": [
         {
             "name": "alcaeus/mongo-php-adapter",
@@ -756,34 +756,31 @@
     "packages-dev": [
         {
             "name": "ocramius/lazy-property",
-            "version": "1.0.1",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Ocramius/LazyProperty.git",
-                "reference": "6ebe14852b08a89d28c064a75ea88dbe88dad07c"
+                "reference": "7294b65d31d6071cb98a3b661ba7152101a499dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/LazyProperty/zipball/6ebe14852b08a89d28c064a75ea88dbe88dad07c",
-                "reference": "6ebe14852b08a89d28c064a75ea88dbe88dad07c",
+                "url": "https://api.github.com/repos/Ocramius/LazyProperty/zipball/7294b65d31d6071cb98a3b661ba7152101a499dc",
+                "reference": "7294b65d31d6071cb98a3b661ba7152101a499dc",
                 "shasum": ""
             },
             "require": {
-                "php": "~5.4|~7.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0|~5.0",
-                "squizlabs/php_codesniffer": "~2.5"
+                "doctrine/coding-standard": "^8.2.0",
+                "infection/infection": "^0.20.2",
+                "phpunit/phpunit": "^9.5.1",
+                "vimeo/psalm": "^4.4.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "LazyProperty\\": "src"
+                "psr-4": {
+                    "LazyProperty\\": "src/LazyProperty"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -795,6 +792,11 @@
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
                     "homepage": "http://ocramius.github.io/"
+                },
+                {
+                    "name": "Niklas Schöllhorn",
+                    "email": "schoellhorn.niklas@gmail.com",
+                    "role": "Maintainer"
                 }
             ],
             "description": "A library that provides lazy instantiation logic for object properties",
@@ -809,7 +811,14 @@
                 "issues": "https://github.com/Ocramius/LazyProperty/issues",
                 "source": "https://github.com/Ocramius/LazyProperty/tree/master"
             },
-            "time": "2016-01-21T16:19:39+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2021-01-17T18:21:07+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",


### PR DESCRIPTION
_Replaces #541 (wrong branch)_

Possible fix for dependabot updates failing:
- https://github.com/perftools/xhgui/actions/runs/14135989901/job/39607725616

Note: Drop 7.2, 7.3 from CI tests, code still probably works, but not tested so can break in the future.

Note: Branch protection rules needed to be updated to remove 7.2 and 7.3:
- https://github.com/perftools/xhgui/settings/branch_protection_rules/19346307