### PR TITLE
Add 8.0 to tests-mongodb

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         php:
           - "7.4"
+          - "8.0"
 
     services:
       mongodb:


### PR DESCRIPTION
Was it forgotten? or omitted deliberately?
- https://github.com/perftools/xhgui/pull/509#issuecomment-2763303685