### PR TITLE
CI: Skip php 7.4 testing

### DIFF
--- a/.github/workflows/tests-mongodb.yml
+++ b/.github/workflows/tests-mongodb.yml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - "7.4"
           - "8.0"
 
     services:

--- a/.github/workflows/tests-mysql.yml
+++ b/.github/workflows/tests-mysql.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.4"
           - "8.0"
 
     services:

--- a/.github/workflows/tests-pgsql.yml
+++ b/.github/workflows/tests-pgsql.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.4"
           - "8.0"
 
     services:

--- a/.github/workflows/tests-sqlite.yml
+++ b/.github/workflows/tests-sqlite.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.4"
           - "8.0"
 
     steps:


### PR DESCRIPTION
Just to simplify CI process:
- https://github.com/perftools/xhgui/pull/510

Note: Branch protection rules needed to be updated to remove 7.4:
- https://github.com/perftools/xhgui/settings/branch_protection_rules/19346307