### PR TITLE
Fix: Validate parse_url being string (exclude null)

### DIFF
--- a/src/Saver/NormalizingSaver.php
+++ b/src/Saver/NormalizingSaver.php
@@ -15,7 +15,11 @@ class NormalizingSaver implements SaverInterface
         // extract "get" from "url"
         // profiler no longer needs to send "get" over the wire.
         // the individual savers may choose not to store this down separately
-        $query = parse_url($data['meta']['url'], PHP_URL_QUERY);
+        $url = $data['meta']['url'];
+        if (!$url) {
+            throw new RuntimeException('No url provided');
+        }
+        $query = parse_url($url, PHP_URL_QUERY);
         parse_str($query, $get);
         $data['meta']['get'] = $get;
 


### PR DESCRIPTION
```
17x: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated
```

- https://github.com/perftools/xhgui/actions/runs/14159378459/job/39662750599?pr=548#step:8:24