### PR TITLE
Build: Upgrade composer 1.10 -> 2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN chmod -R a+rX /app
 FROM php AS build
 WORKDIR /app
 ARG COMPOSER_FLAGS="--no-interaction --ansi --no-dev"
-COPY --from=composer:1.10 /usr/bin/composer /usr/bin/
+COPY --from=composer:2.7 /usr/bin/composer /usr/bin/
 
 COPY --from=source /app/composer.* ./
 COPY --from=source /app/vendor ./vendor


### PR DESCRIPTION
> Your requirements could not be resolved to an installable set of packages.
>
>   Problem 1
>     - jean85/pretty-package-versions 2.1.1 requires composer-runtime-api ^2.1.0 -> no matching package found.
>     - jean85/pretty-package-versions 2.1.1 requires composer-runtime-api ^2.1.0 -> no matching package found.
>     - Installation request for jean85/pretty-package-versions 2.1.1 -> satisfiable by jean85/pretty-package-versions[2.1.1].
>

$ composer why jean85/pretty-package-versions
> mongodb/mongodb 1.10.1 requires jean85/pretty-package-versions (^1.2 || ^2.0.1)

Refs
- https://github.com/perftools/xhgui/actions/runs/16113766826